### PR TITLE
Updates referral logic

### DIFF
--- a/src/custom_modules/DAO_modules/referrals.ts
+++ b/src/custom_modules/DAO_modules/referrals.ts
@@ -100,23 +100,81 @@ async function getDonorAnswers(donorID) {
  * Adds a referral record
  * @param {number} referralTypeID
  * @param {number} donorID
+ * @param {string} session Used to isolate referrals of the a single session in the widget. We need this to seperate anonymous donors.
  * @param {string} otherComment
+ * @returns {boolean} Indicates whether the record was saved
  */
-async function addRecord(referralTypeID, donorID, otherComment) {
-  let [query] = await DAO.query(
-    `INSERT INTO Referral_records (ReferralID, UserID, other_comment) VALUES (?,?,?)`,
-    [referralTypeID, donorID, otherComment]
+async function addRecord(referralTypeID, donorID, session, otherComment) {
+  let result = await DAO.query(
+    `INSERT INTO Referral_records (ReferralID, UserID, website_session, other_comment) VALUES (?,?,?,?)`,
+    [referralTypeID, donorID, session, otherComment]
   );
 
-  return true;
+  if (result[0].affectedRows > 0) return true;
+  else return false;
+}
+
+/**
+ * Checks whether a record with the given donor id and referral type id and session exists, return true or false
+ * @param {number} referralTypeID
+ * @param {number} donorID
+ * @param {string} session Used to isolate referrals of the a single session in the widget. We need this to seperate anonymous donors.
+ * @returns {boolean} Indicates whether the record is exist
+ */
+async function checkRecordExist(referralTypeID, donorID, session) {
+  let [result] = await DAO.query(
+    `select * from Referral_records where ReferralID = ? and UserID = ? and website_session = ?`,
+    [referralTypeID, donorID, session]
+  );
+
+  if (result.length > 0) return true;
+  else return false;
 }
 //endregion
 
 //region Modify
+/**
+ * Updates the comment field for an existing referral record with a given donor id, referral type id and session
+ * @param {number} referralTypeID
+ * @param {number} donorID
+ * @param {string} session Used to isolate referrals of the a single session in the widget. We need this to seperate anonymous donors.
+ * @param {string} otherComment
+ * @returns {boolean} Indicates whether the record was updated
+ */
+async function updateRecordComment(
+  referralTypeID,
+  donorID,
+  session,
+  otherComment
+) {
+  let result = await DAO.query(
+    `UPDATE Referral_records SET other_comment = ? WHERE UserID = ? AND ReferralID = ? AND website_session = ?`,
+    [otherComment, donorID, referralTypeID, session]
+  );
 
+  if (result[0].affectedRows > 0) return true;
+  else return false;
+}
 //endregion
 
 //region Delete
+/**
+ * Removes a record with a given donor id and referral type id
+ * @param {number} referralTypeID
+ * @param {number} donorID
+ * @param {string} session Used to isolate referrals of the a single session in the widget. We need this to seperate anonymous donors.
+ * @returns {boolean} Indicates whether the record was deleted
+ */
+async function deleteRecord(referralTypeID, donorID, session) {
+  let result = await DAO.query(
+    `DELETE FROM Referral_records WHERE ReferralID = ? and UserID = ? and website_session = ?`,
+    [referralTypeID, donorID, session]
+  );
+
+  if (result[0].affectedRows > 0) return true;
+  else return false;
+}
+
 //endregion
 
 //Helpers
@@ -126,4 +184,7 @@ export const referrals = {
   getDonorAnswered,
   getDonorAnswers,
   addRecord,
+  updateRecordComment,
+  checkRecordExist,
+  deleteRecord,
 };

--- a/src/routes/referrals.ts
+++ b/src/routes/referrals.ts
@@ -1,61 +1,110 @@
-import { DAO } from '../custom_modules/DAO'
+import { DAO } from "../custom_modules/DAO";
 
-const express = require('express')
-const router = express.Router()
-const bodyParser = require('body-parser')
-const urlEncodeParser = bodyParser.urlencoded({ extended: false })
+const express = require("express");
+const router = express.Router();
+const bodyParser = require("body-parser");
+const urlEncodeParser = bodyParser.urlencoded({ extended: false });
 
-
-router.get("/types", async (req,res, next) => {
+router.get("/types", async (req, res, next) => {
   try {
-    let types = await DAO.referrals.getTypes()
+    let types = await DAO.referrals.getTypes();
 
     res.json({
       status: 200,
-      content: types
-    })
+      content: types,
+    });
+  } catch (ex) {
+    next(ex);
   }
-  catch(ex) {
-    next(ex)
+});
+
+router.get("/aggregate", async (req, res, next) => {
+  try {
+    let aggregate = await DAO.referrals.getAggregate();
+
+    res.json({
+      status: 200,
+      content: aggregate,
+    });
+  } catch (ex) {
+    next(ex);
   }
-})
+});
 
-router.get("/aggregate", async (req,res, next) => {
-    try {
-        let aggregate = await DAO.referrals.getAggregate()
+router.post("/", async (req, res, next) => {
+  try {
+    let parsedData = req.body;
+    if (typeof parsedData.referralID === "undefined")
+      throw new Error("Missing parameter referralID");
+    if (typeof parsedData.donorID === "undefined")
+      throw new Error("Missing parameter donorID");
+    if (typeof parsedData.active === "undefined")
+      throw new Error("Missing parameter active");
+    if (typeof parsedData.session === "undefined")
+      throw new Error("Missing parameter session");
 
+    if (typeof parsedData.comment === "undefined") parsedData.comment = null;
+
+    const OTHER_REFERRAL_ID = 10;
+
+    if (parsedData.active) {
+      const otherRecordExists = await DAO.referrals.checkRecordExist(
+        parsedData.referralID,
+        parsedData.donorID,
+        parsedData.session
+      );
+
+      if (otherRecordExists) {
+        /**
+         * If the record is already in the database, we only need to update the comment
+         * as there can be only one record of a certain referral type per donor and session.
+         */
+        if (parsedData.referralID === OTHER_REFERRAL_ID) {
+          const updated = await DAO.referrals.updateRecordComment(
+            parsedData.referralID,
+            parsedData.donorID,
+            parsedData.session,
+            parsedData.comment
+          );
+          if (updated) {
+            res.json({
+              status: 200,
+            });
+          } else {
+            throw new Error(
+              "Failed to update existing referral record with new comment."
+            );
+          }
+        }
+      } else {
+        let status = await DAO.referrals.addRecord(
+          parsedData.referralID,
+          parsedData.donorID,
+          parsedData.session,
+          parsedData.comment
+        );
+
+        if (!status) throw new Error("Failed to add record");
         res.json({
+          status: 200,
+          content: status,
+        });
+      }
+    } else {
+      let status = await DAO.referrals.deleteRecord(
+        parsedData.referralID,
+        parsedData.donorID,
+        parsedData.session
+      );
+      if (!status) throw new Error("Failure to delete record");
+      res.json({
         status: 200,
-        content: aggregate
-        })
+        content: status,
+      });
     }
-    catch(ex) {
-        next(ex)
-    }
-})
+  } catch (ex) {
+    next(ex);
+  }
+});
 
-router.post("/", async(req,res,next) => {
-    try {
-        let parsedData = req.body
-        if (!parsedData.referralID)
-            throw new Error("Missing parameter referralID")
-
-        if (!parsedData.donorID)
-            throw new Error("Missing parameter donorID")
-
-        if (parsedData.comment === undefined)
-            parsedData.comment = null
-
-        let status = await DAO.referrals.addRecord(parsedData.referralID, parsedData.donorID, parsedData.comment)
-    
-        res.json({
-            status: 200,
-            content: status
-        })
-      }
-      catch(ex) {
-        next(ex)
-      }
-})
-
-module.exports = router
+module.exports = router;


### PR DESCRIPTION
Website session is sent to the backend alongside with donorid and referralid, such that we may differentiate between different anonymous donors.

Incompatible with current frontend, dependent on PR in main site. Should be merged at the same time.