### PR TITLE
Use native internationalization API for currency formatting

### DIFF
--- a/src/__test__/mail.spec.ts
+++ b/src/__test__/mail.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+
+const { formatCurrency } = require("../custom_modules/mail");
+
+describe("formatCurrency", function () {
+
+    it("should use space character (U+00a0) as thousands separator", () => {
+        expect(formatCurrency(123456789)).to.equal("123 456 789");
+        expect(formatCurrency(12345)).to.equal("12 345");
+    });
+
+    it("should use comma (,) as decimal separator", () => {
+        expect(formatCurrency(123.11)).to.equal("123,11");
+        expect(formatCurrency(123.12)).to.equal("123,12");
+    });
+
+    it("should handle numeric string as input", () => {
+        expect(formatCurrency("1234")).to.equal("1 234");
+    });
+
+    it("should handle number as input", () => {
+        expect(formatCurrency(1234)).to.equal("1 234");
+    });
+})

--- a/src/custom_modules/mail.ts
+++ b/src/custom_modules/mail.ts
@@ -36,12 +36,8 @@ function formatDateText(date) {
   return `${date.getDate()}. ${months[date.getMonth()]} ${date.getFullYear()}`;
 }
 
-function formatCurrency(currencyString) {
-  return Number.parseFloat(currencyString)
-    .toFixed(2)
-    .replace(/(\d)(?=(\d\d\d)+(?!\d))/g, "$1,")
-    .replace(",", " ")
-    .replace(".", ",");
+export function formatCurrency(currencyString) {
+  return new Intl.NumberFormat('no-NO', {  maximumFractionDigits: 2 }).format(currencyString)
 }
 
 // Reusable HTML elements
@@ -173,10 +169,7 @@ export async function sendDonationReciept(donationID, reciever = null) {
             ? " " + donation.donor
             : "") +
           ",",
-        //Add thousand seperator regex at end of amount
-        donationSum: donation.sum
-          .toString()
-          .replace(/\B(?=(\d{3})+(?!\d))/g, "&#8201;"),
+        donationSum: formatCurrency(donation.sum),
         organizations: organizations,
         donationDate: moment(donation.timestamp).format("DD.MM YYYY"),
         paymentMethod: decideUIPaymentMethod(donation.paymentMethod),
@@ -248,10 +241,7 @@ export async function sendEffektDonationReciept(donationID, reciever = null) {
             ? " " + donation.donor
             : "") +
           ",",
-        //Add thousand seperator regex at end of amount
-        donationSum: donation.sum
-          .toString()
-          .replace(/\B(?=(\d{3})+(?!\d))/g, "&#8201;"),
+        donationSum: formatCurrency(donation.sum),
         organizations: organizations,
         donationDate: moment(donation.timestamp).format("DD.MM YYYY"),
         paymentMethod: decideUIPaymentMethod(donation.paymentMethod),
@@ -285,10 +275,9 @@ function formatOrganizationsFromSplit(split, sum) {
 
     return {
       name: org.full_name,
-      //Add thousand seperator regex at end of amount
       amount:
         (roundedAmount != amount ? "~ " : "") +
-        roundedAmount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, "&#8201;"),
+        formatCurrency(roundedAmount),
       percentage: parseFloat(org.share),
     };
   });
@@ -637,9 +626,7 @@ export async function sendTaxDeductions(taxDeductionRecord, year) {
       templateName: "taxDeduction",
       templateData: {
         header: "Hei " + taxDeductionRecord.firstname + ",",
-        donationSum: taxDeductionRecord.amount
-          .toString()
-          .replace(/\B(?=(\d{3})+(?!\d))/g, "&#8201;"),
+        donationSum: formatCurrency(taxDeductionRecord.amount),
         fullname: taxDeductionRecord.fullname,
         ssn: taxDeductionRecord.ssn,
         year: year.toString(),


### PR DESCRIPTION
Regex based formatting logic seems to have some bugs. Trying to fix - https://github.com/stiftelsen-effekt/effekt-backend/issues/448 and https://github.com/stiftelsen-effekt/effekt-backend/issues/446

Changes - 
- Use native Internationalization for number formatting - [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format)
- Unify currency formatting to use the same logic
- Add basic tests

Note: Haven't been able to test it by sending an email, any pointers on how to do that would be great.