### PR TITLE
Adds functionality for assigning tax units to KIDs

### DIFF
--- a/src/custom_modules/DAO_modules/tax.ts
+++ b/src/custom_modules/DAO_modules/tax.ts
@@ -239,6 +239,26 @@ async function updateTaxUnit(id: number, taxUnit: TaxUnit): Promise<number> {
 
   return result.affectedRows;
 }
+
+/**
+ *  Updates all KID numbers missing a tax unit for a single donor
+ * @param {number} taxUnitID The id of the tax unit
+ * @param {TaxUnit} donorID The donor ID
+ * @returns {number} The number of rows affected
+ */
+async function updateKIDsMissingTaxUnit(taxUnitID: number, donorID: number): Promise<boolean> {
+  const [result] = await DAO.execute<ResultSetHeader | OkPacket>(
+    `
+      UPDATE Combining_table
+      SET Tax_unit_ID = ?
+      WHERE Tax_unit_ID IS NULL
+      AND Donor_ID = ?
+    `,
+    [taxUnitID, donorID]
+  );
+
+  return true
+}
 //endregion
 
 //region Delete
@@ -403,6 +423,7 @@ export const tax = {
   getByDonorId,
   getByKID,
   getByDonorIdAndSsn,
+  updateKIDsMissingTaxUnit,
   addTaxUnit,
   updateTaxUnit,
   deleteById,

--- a/src/routes/donors.ts
+++ b/src/routes/donors.ts
@@ -466,7 +466,16 @@ router.post(
       var taxUnitId = await DAO.tax.addTaxUnit(donor.id, ssn, name);
       const taxUnit = await DAO.tax.getById(taxUnitId);
 
+      // If successfully created tax unit
       if (taxUnit) {
+        const taxUnits = await DAO.tax.getByDonorId(donor.id);
+
+        // if this is the first tax unit created for the donor (also counts archived tax units)
+        if (taxUnits.length === 1) {
+          // Update the donor's KID numbers missing a tax unit
+          await DAO.tax.updateKIDsMissingTaxUnit(taxUnitId, donor.id)
+        }
+
         return res.json({
           status: 200,
           content: taxUnit,

--- a/src/routes/tax.ts
+++ b/src/routes/tax.ts
@@ -81,4 +81,22 @@ router.put("/:id", async (req, res, next) => {
   }
 });
 
+router.put(
+  "/donations/assign",
+  //authMiddleware.isAdmin,
+  async (req, res, next) => {
+    try {
+      const singleTaxUnits = await DAO.donors.getIDsWithOneTaxUnit()
+
+      for (let i = 0; i < singleTaxUnits.length; i++) {
+        await DAO.tax.updateKIDsMissingTaxUnit(singleTaxUnits[i]["ID"], singleTaxUnits[i]["Donor_ID"])
+      }
+
+      return res.json({status: 200});
+    } catch (ex) {
+      next(ex);
+    }
+  }
+);
+
 module.exports = router;

--- a/src/routes/tax.ts
+++ b/src/routes/tax.ts
@@ -1,4 +1,5 @@
 import { DAO } from "../custom_modules/DAO";
+import * as authMiddleware from "../custom_modules/authorization/authMiddleware";
 
 const express = require("express");
 const router = express.Router();
@@ -83,7 +84,7 @@ router.put("/:id", async (req, res, next) => {
 
 router.put(
   "/donations/assign",
-  //authMiddleware.isAdmin,
+  authMiddleware.isAdmin,
   async (req, res, next) => {
     try {
       const singleTaxUnits = await DAO.donors.getIDsWithOneTaxUnit()


### PR DESCRIPTION
Closes #487

**Important implementation decision:**
The issue says only to assign tax units to KID numbers with donations in the current year, but this will regardless also affect donations from previous years due to tax units not being linked to donations directly but to their KID numbers. Should we just assign the first tax unit created to all KIDs for that donor? If it's a problem that donations from previous years get assigned a new tax unit, then we need to change the database.