### PR TITLE
Don't specify database in validation call

### DIFF
--- a/src/custom_modules/DAO_modules/avtalegiroagreements.ts
+++ b/src/custom_modules/DAO_modules/avtalegiroagreements.ts
@@ -556,7 +556,7 @@ async function getByPaymentDate(dayInMonth) {
  * @returns {Array<{ date: String, expected: number, actual: number, diff: number }>}
  */
 async function getValidationTable() {
-  let [rows] = await DAO.query(`call EffektDonasjonDB.get_avtalegiro_validation()`);
+  let [rows] = await DAO.query(`call get_avtalegiro_validation()`);
 
   return rows[0];
 }


### PR DESCRIPTION
#517 

Example before and after:
```
geeffektivt@localhost:GeEffektivtDev>
 call EffektDonasjonDB.get_avtalegiro_validation();
(1370, "execute command denied to user 'geeffektivt'@'%' for routine 'EffektDonasjonDB.get_avtalegiro_validation'")

geeffektivt@localhost:GeEffektivtDev>
 call get_avtalegiro_validation();
+------+----------+--------+------+
| date | expected | actual | diff |
+------+----------+--------+------+
+------+----------+--------+------+
```

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

⏲️ Time spent on CR:

⏲️ Time spent on QA:
