### PR TITLE
Handle undefined taxunit for anonymous Vipps agreements

### DIFF
--- a/src/routes/vipps.ts
+++ b/src/routes/vipps.ts
@@ -509,7 +509,7 @@ router.put("/agreement/:urlcode/distribution", jsonBody, async (req, res, next) 
 
     const donorId = await DAO.donors.getIDByAgreementCode(agreementCode);
     const standardDistribution = req.body.distribution.standardDistribution;
-    let taxUnitId: number | undefined = req.body.distribution.taxUnit.id;
+    let taxUnitId: number | undefined = req.body.distribution.taxUnit?.id;
 
     const shares = req.body.distribution.shares;
 


### PR DESCRIPTION
Fixes a bug when changing the distribution of anonymous agreements due to a missing tax unit.

The new response statuses do not seem to affect any of our functionality, as we don't explicitly check the status code in any parts of the code.

451 from main-site repo: https://github.com/stiftelsen-effekt/main-site/issues/451

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

⏲️ Time spent on CR:

⏲️ Time spent on QA:
