### PR TITLE
Add simple Docker-Compose file and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ Then run:
 ```sh
 docker run -d \
 --name effekt-mysql \
--p 3306:3306 -e \
-MYSQL_ROOT_PASSWORD=effekt \
-MYSQL_DATABASE=EffektDonasjonDB_Local \
+-p 3306:3306 \
+-e MYSQL_ROOT_PASSWORD=effekt \
+-e MYSQL_DATABASE=EffektDonasjonDB_Local \
 -v effekt-mysql_volume:/var/lib/mysql \
 mysql:latest
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+
+volumes:
+  effekt-mysql_volume:
+
+services:
+  db:
+    image: mysql:latest
+    container_name: effekt-mysql
+    ports:
+      - 3306:3306
+    command: ["--log_bin_trust_function_creators=1"]
+    environment:
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_ROOT_PASSWORD: ${DB_PASS}
+    volumes:
+      - effekt-mysql_volume:/var/lib/mysql
+    restart: unless-stopped


### PR DESCRIPTION
Created a docker-compose file as it would be nice to quickly setup the MySQL database with docker. Can be updated for further integration with app, if needed/beneficial. Also updated README.md

_As a sidenote,_ I also explored the possibility automatically run `npx prisma migrate reset` command with the compose file and the env. variable `/docker-entrypoint-initdb.d`, but that unfortunately seemed to require a _hacky_ solution... So running  the prisma commands manually seems to be the cleaner solution.  Discussion of this [with Postgres](https://github.com/docker-library/postgres/issues/179) and [with Prisma](https://github.com/prisma/prisma/discussions/12179)

- closes #linked-issue-nr
#562 #537 
---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

⏲️ Time spent on CR:

⏲️ Time spent on QA:
