### PR TITLE
Enable non-root db user in compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 DB_HOST='localhost'
 DB_NAME='EffektDonasjonDB_Local'
-DB_USER='root'
+DB_USER='myuser'
 DB_PASS='effekt'
 DB_URL="mysql://${DB_USER}:${DB_PASS}@${DB_HOST}/${DB_NAME}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     environment:
       MYSQL_DATABASE: ${DB_NAME}
       MYSQL_ROOT_PASSWORD: ${DB_PASS}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASS}
     volumes:
       - effekt-mysql_volume:/var/lib/mysql
     restart: unless-stopped


### PR DESCRIPTION
Useful to have a non-root user to emulate production behavior, for example to run migrations

To reset with this user you have to clear the volume, something like:
```sh
docker compose down --volume
docker compose up --detach db
```

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

⏲️ Time spent on CR:

⏲️ Time spent on QA:
