### PR TITLE
Remove FK that does not exist in Prod database

### DIFF
--- a/prisma/migrations/03_remove_foreign_key/migration.sql
+++ b/prisma/migrations/03_remove_foreign_key/migration.sql
@@ -1,0 +1,2 @@
+-- DropForeignKey
+ALTER TABLE `Combining_table` DROP FOREIGN KEY `Combining_table_KID_fkey`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,10 +26,9 @@ model Auth0_users {
 }
 
 model AvtaleGiro_replaced_distributions {
-  Original_AvtaleGiro_KID String            @db.VarChar(15)
-  Replacement_KID         String            @id @db.VarChar(15)
-  Timestamp               DateTime?         @default(now()) @db.DateTime(0)
-  Combining_table         Combining_table[]
+  Original_AvtaleGiro_KID String    @db.VarChar(15)
+  Replacement_KID         String    @id @db.VarChar(15)
+  Timestamp               DateTime? @default(now()) @db.DateTime(0)
 }
 
 model Avtalegiro_agreements {
@@ -58,18 +57,17 @@ model Avtalegiro_shipment {
 }
 
 model Combining_table {
-  Donor_ID                          Int
-  Distribution_ID                   Int
-  Tax_unit_ID                       Int?
-  KID                               String                             @db.VarChar(16)
-  timestamp_created                 DateTime?                          @default(now()) @db.DateTime(0)
-  Meta_owner_ID                     Int                                @default(3)
-  Replaced_old_organizations        Int?                               @db.TinyInt
-  Standard_split                    Boolean?
-  AvtaleGiro_replaced_distributions AvtaleGiro_replaced_distributions? @relation(fields: [KID], references: [Replacement_KID])
-  Distribution                      Distribution                       @relation(fields: [Distribution_ID], references: [ID], onDelete: Cascade, map: "fk_Combining_to_Distribution")
-  Donors                            Donors                             @relation(fields: [Donor_ID], references: [ID], onDelete: Cascade, map: "fk_Combining_to_Donor")
-  Tax_unit                          Tax_unit?                          @relation(fields: [Tax_unit_ID], references: [ID], map: "fk_Combining_to_TaxUnit")
+  Donor_ID                   Int
+  Distribution_ID            Int
+  Tax_unit_ID                Int?
+  KID                        String       @db.VarChar(16)
+  timestamp_created          DateTime?    @default(now()) @db.DateTime(0)
+  Meta_owner_ID              Int          @default(3)
+  Replaced_old_organizations Int?         @db.TinyInt
+  Standard_split             Boolean?
+  Distribution               Distribution @relation(fields: [Distribution_ID], references: [ID], onDelete: Cascade, map: "fk_Combining_to_Distribution")
+  Donors                     Donors       @relation(fields: [Donor_ID], references: [ID], onDelete: Cascade, map: "fk_Combining_to_Donor")
+  Tax_unit                   Tax_unit?    @relation(fields: [Tax_unit_ID], references: [ID], map: "fk_Combining_to_TaxUnit")
 
   @@id([Donor_ID, Distribution_ID, KID])
   @@index([KID], map: "KID")


### PR DESCRIPTION
Encountered a weird foreign-key restriction on the local database when working with generating test-data. 

![image](https://github.com/stiftelsen-effekt/effekt-backend/assets/30749741/0b2bd538-bb7f-478b-80b4-133ce2fca53c)

This enforces that each KID has an entry in `AvtaleGiro_replaced_distributions` that matches `replacementKID`, which does not make much sense (to my knowledge), as `replacementKID` is only created when needed. The FK does not seem to exist in the PROD database either: 


![image](https://github.com/stiftelsen-effekt/effekt-backend/assets/30749741/3f44b7b3-bc3c-407c-990b-9fc987b84c48)


My guess is that the FK tries to replicate this FK from PROD:  

![image](https://github.com/stiftelsen-effekt/effekt-backend/assets/30749741/454a546c-ef13-4d5b-8e0d-2a2e5d574763)
![image](https://github.com/stiftelsen-effekt/effekt-backend/assets/30749741/0c7845ed-757e-4c3b-87ec-644fff0c4dc4)


However, this FK references the non unique column KID in Combining_table, which is not possible to reproduce in schema.prisma. From SQL Server docs "a foreign key must reference either the primary key or a unique key of the parent table.", but in MySQL it is allowed but not recommended. My guess is that it will remain in PROD, as it is already created and is not really needed for the local database set up

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

⏲️ Time spent on CR:

⏲️ Time spent on QA:
