### PR TITLE
Ignore non-example .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@ node_modules/
 .idea/
 .vscode/
 out/
-env.list
 dist/
 .nyc_output/
-.env
-.env.local
+.env*
+!.env.example


### PR DESCRIPTION
Ignore e.g. `.env.production`