### PR TITLE
Move typescript to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "ssh2-sftp-client": "^9.1.0",
     "swagger-jsdoc": "^6.1.0",
     "swagger-ui-express": "^4.2.0",
-    "typescript": "^4.5.4",
     "validator": "^13.7.0"
   },
   "devDependencies": {
@@ -120,6 +119,7 @@
     "supertest": "^6.1.6",
     "ts-loader": "^9.2.6",
     "ts-node": "^10.4.0",
+    "typescript": "^4.5.4",
     "webpack-cli": "^4.9.1"
   },
   "lint-staged": {


### PR DESCRIPTION
Typescript is not needed in runtime, right?

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
