### PR TITLE
Add typescript back to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "ssh2-sftp-client": "^9.1.0",
     "swagger-jsdoc": "^6.1.0",
     "swagger-ui-express": "^4.2.0",
+    "typescript": "^4.5.4",
     "ts-node": "^10.4.0",
     "validator": "^13.7.0"
   },
@@ -119,7 +120,6 @@
     "sinon": "^15.0.4",
     "supertest": "^6.1.6",
     "ts-loader": "^9.2.6",
-    "typescript": "^4.5.4",
     "webpack-cli": "^4.9.1"
   },
   "lint-staged": {


### PR DESCRIPTION
Looks like ts-node indeed needs typescript in the dependencies to run properly

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [x] Packages updated
- [x] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
