### PR TITLE
Backwards compatible response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "swagger-jsdoc": "^6.1.0",
         "swagger-ui-express": "^4.2.0",
         "ts-node": "^10.4.0",
+        "typescript": "4.9.5",
         "validator": "^13.7.0"
       },
       "devDependencies": {
@@ -95,7 +96,6 @@
         "sinon": "^15.0.4",
         "supertest": "^6.1.6",
         "ts-loader": "^9.2.6",
-        "typescript": "^4.5.4",
         "webpack-cli": "^4.9.1"
       },
       "engines": {
@@ -8239,9 +8239,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15144,9 +15144,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "ssh2-sftp-client": "^9.1.0",
     "swagger-jsdoc": "^6.1.0",
     "swagger-ui-express": "^4.2.0",
-    "typescript": "^4.5.4",
+    "typescript": "4.9.5",
     "ts-node": "^10.4.0",
     "validator": "^13.7.0"
   },

--- a/src/routes/avtalegiro.ts
+++ b/src/routes/avtalegiro.ts
@@ -106,6 +106,25 @@ router.get("/agreement/:id", authMiddleware.isAdmin, async (req, res, next) => {
     const taxUnit = await DAO.tax.getByKID(agreement.KID);
     const donor = await DAO.donors.getByKID(agreement.KID);
 
+    type BackwardsCompatibleResponse = {
+      status: 200;
+      content: {
+        ID: number;
+        distribution: {
+          KID: string;
+          donor: unknown;
+          taxUnit: unknown;
+          standardDistribution: boolean;
+          shares: Array<{
+            full_name: string;
+            abbriv: string;
+            id: number;
+            share: string;
+          }>;
+        };
+      };
+    };
+
     return res.json({
       status: 200,
       content: {
@@ -114,7 +133,7 @@ router.get("/agreement/:id", authMiddleware.isAdmin, async (req, res, next) => {
         donor,
         taxUnit,
       },
-    });
+    } satisfies BackwardsCompatibleResponse);
   } catch (ex) {
     next(ex);
   }

--- a/src/routes/distributions.ts
+++ b/src/routes/distributions.ts
@@ -118,6 +118,23 @@ router.get("/:KID", authMiddleware.isAdmin, async (req, res, next) => {
     const distribution = await DAO.distributions.getSplitByKID(req.params.KID);
     const taxUnit = await DAO.tax.getByKID(req.params.KID);
     const donor = await DAO.donors.getByKID(req.params.KID);
+
+    type BackwardsCompatibleResponse = {
+      status: 200;
+      content: {
+        KID: string;
+        donor: unknown;
+        taxUnit: unknown;
+        standardDistribution: boolean;
+        shares: Array<{
+          full_name: string;
+          abbriv: string;
+          id: number;
+          share: string;
+        }>;
+      };
+    };
+
     return res.json({
       status: 200,
       content: {
@@ -126,7 +143,7 @@ router.get("/:KID", authMiddleware.isAdmin, async (req, res, next) => {
         taxUnit,
         distribution,
       },
-    });
+    } satisfies BackwardsCompatibleResponse);
   } catch (ex) {
     if (ex.message.indexOf("NOT FOUND") !== -1)
       res.status(404).send({
@@ -155,10 +172,25 @@ router.get(
        */
       throw new Error("Not backwards compatible with old distributions object");
 
+      type BackwardsCompatibleResponse = {
+        status: 200;
+        content: Array<{
+          donorID: number;
+          distributions: Array<{
+            kid: string;
+            shares: Array<{
+              id: number;
+              name: string;
+              share: string;
+            }>;
+          }>;
+        }>;
+      };
+
       return res.json({
         status: 200,
         content: distributions,
-      });
+      } satisfies BackwardsCompatibleResponse);
     } catch (ex) {
       if (ex.message.indexOf("NOT FOUND") !== -1)
         res.status(404).send({

--- a/src/routes/donors.ts
+++ b/src/routes/donors.ts
@@ -1209,10 +1209,24 @@ router.get(
         (distributions[result.index] as any).standardDistribution = result.standardDistribution;
       }
 
+      type BackwardsCompatibleResponse = {
+        status: 200;
+        content: Array<{
+          kid: string;
+          taxUnit: unknown;
+          standardDistribution: boolean;
+          shares: Array<{
+            id: number;
+            name: string;
+            share: string;
+          }>;
+        }>;
+      };
+
       return res.json({
         status: 200,
         content: distributions,
-      });
+      } satisfies BackwardsCompatibleResponse);
     } catch (ex) {
       next(ex);
     }

--- a/src/routes/vipps.ts
+++ b/src/routes/vipps.ts
@@ -118,7 +118,25 @@ router.get("/agreement/anonymous/:urlcode", async (req, res, next) => {
 
     const distribution = await DAO.distributions.getSplitByKID(KID);
 
-    res.status(200).json({ content: { agreement, distribution } });
+    type BackwardsCompatibleResponse = {
+      content: {
+        agreement: unknown;
+        distribution: {
+          kid: string;
+          standardDistribution: boolean;
+          shares: Array<{
+            abbriv: string;
+            name: string;
+            id: number;
+            share: string | number;
+          }>;
+        };
+      };
+    };
+
+    res
+      .status(200)
+      .json({ content: { agreement, distribution } } satisfies BackwardsCompatibleResponse);
   } catch (ex) {
     next({ ex });
   }


### PR DESCRIPTION
I'm thinking we could just use the typescript compiler to catch regressions on the API return types. This will introduce some TS errors, due to the current inferred response type not satisfying the previous one.

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
