### PR TITLE
Fix tax unit connection re-resolving standard split to current orgs

### DIFF
--- a/src/__test__/DAO/distributions.add.spec.ts
+++ b/src/__test__/DAO/distributions.add.spec.ts
@@ -1,0 +1,205 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import { DAO } from "../../custom_modules/DAO";
+import { Distribution } from "../../schemas/types";
+
+describe("DAO distributions.add", () => {
+  const standardSplitDistribution: Distribution = {
+    kid: "123456789012345",
+    donorId: 1,
+    taxUnitId: 19,
+    causeAreas: [
+      {
+        id: 1,
+        standardSplit: true,
+        percentageShare: "100",
+        organizations: [
+          {
+            id: 12,
+            percentageShare: "100",
+          },
+        ],
+      },
+    ],
+  };
+
+  const customSplitDistribution: Distribution = {
+    kid: "123456789012345",
+    donorId: 1,
+    taxUnitId: 19,
+    causeAreas: [
+      {
+        id: 1,
+        standardSplit: false,
+        percentageShare: "100",
+        organizations: [
+          {
+            id: 1,
+            percentageShare: "60",
+          },
+          {
+            id: 2,
+            percentageShare: "40",
+          },
+        ],
+      },
+    ],
+  };
+
+  let transactionQueryStub: sinon.SinonStub;
+  let daoQueryStub: sinon.SinonStub;
+  let metaStub: sinon.SinonStub;
+  let startTransactionStub: sinon.SinonStub;
+  let commitTransactionStub: sinon.SinonStub;
+  let rollbackTransactionStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    transactionQueryStub = sinon.stub();
+    metaStub = sinon.stub(DAO.meta, "getDefaultOwnerID").resolves(1);
+
+    const connection = {
+      query: transactionQueryStub,
+    } as any;
+
+    startTransactionStub = sinon.stub(DAO, "startTransaction").resolves(connection);
+    commitTransactionStub = sinon.stub(DAO, "commitTransaction");
+    rollbackTransactionStub = sinon.stub(DAO, "rollbackTransaction");
+    // Stub DAO.query for getStandardDistributionByCauseAreaID which uses it directly
+    daoQueryStub = sinon.stub(DAO, "query");
+
+    // Default: distribution insert succeeds
+    transactionQueryStub.onFirstCall().resolves([{ affectedRows: 1 }]);
+    // Default: cause area insert succeeds
+    transactionQueryStub.onSecondCall().resolves([{ affectedRows: 1, insertId: 100 }]);
+    // Default: org insert succeeds
+    transactionQueryStub.onThirdCall().resolves([{ affectedRows: 1 }]);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("Should use provided organizations when standardSplit is false", async () => {
+    await DAO.distributions.add({ distribution: customSplitDistribution });
+
+    expect(daoQueryStub.called).to.be.false;
+
+    // The third query is the org insert - check the values passed
+    const orgInsertArgs = transactionQueryStub.thirdCall.args;
+    const orgRows = orgInsertArgs[1][0];
+    expect(orgRows).to.have.length(2);
+    expect(orgRows[0][1]).to.equal(1); // org id 1
+    expect(orgRows[0][2]).to.equal("60"); // percentage
+    expect(orgRows[1][1]).to.equal(2); // org id 2
+    expect(orgRows[1][2]).to.equal("40"); // percentage
+  });
+
+  it("Should resolve standard split from DB when standardSplit is true and preserveOrganizations is false", async () => {
+    // getStandardDistributionByCauseAreaID uses DAO.query directly
+    daoQueryStub.resolves([[{ ID: 15, full_name: "AGF", std_percentage_share: 100 }], []]);
+
+    await DAO.distributions.add({ distribution: standardSplitDistribution });
+
+    expect(daoQueryStub.calledOnce).to.be.true;
+
+    // The org insert should use the standard split orgs from DB (id 15), not the provided ones (id 12)
+    const orgRows = transactionQueryStub.thirdCall.args[1][0];
+    expect(orgRows).to.have.length(1);
+    expect(orgRows[0][1]).to.equal(15);
+  });
+
+  it("Should use provided organizations when standardSplit is true and preserveOrganizations is true", async () => {
+    await DAO.distributions.add({
+      distribution: standardSplitDistribution,
+      preserveOrganizations: true,
+    });
+
+    // Should NOT call DAO.query for standard split resolution
+    expect(daoQueryStub.called).to.be.false;
+
+    // The org insert should use the provided orgs (id 12), not re-resolve from DB
+    const orgRows = transactionQueryStub.thirdCall.args[1][0];
+    expect(orgRows).to.have.length(1);
+    expect(orgRows[0][1]).to.equal(12);
+    expect(orgRows[0][2]).to.equal("100");
+  });
+
+  it("Should still store standardSplit flag as true in DB even with preserveOrganizations", async () => {
+    await DAO.distributions.add({
+      distribution: standardSplitDistribution,
+      preserveOrganizations: true,
+    });
+
+    // The cause area insert is the second query
+    const causeAreaArgs = transactionQueryStub.secondCall.args[1];
+    // Fourth param is standard_split (1 = true)
+    expect(causeAreaArgs[3]).to.equal(1);
+  });
+
+  it("Should get default meta owner ID when none is provided", async () => {
+    await DAO.distributions.add({ distribution: customSplitDistribution });
+
+    expect(metaStub.calledOnce).to.be.true;
+  });
+
+  it("Should use provided meta owner ID", async () => {
+    await DAO.distributions.add({
+      distribution: customSplitDistribution,
+      metaOwnerID: 42,
+    });
+
+    expect(metaStub.called).to.be.false;
+
+    // Check metaOwnerID is passed to the distribution insert (5th param)
+    const distInsertArgs = transactionQueryStub.firstCall.args[1];
+    expect(distInsertArgs[4]).to.equal(42);
+  });
+
+  it("Should use supplied transaction instead of creating one", async () => {
+    const externalTransaction = { query: transactionQueryStub } as any;
+
+    await DAO.distributions.add({
+      distribution: customSplitDistribution,
+      transaction: externalTransaction,
+    });
+
+    expect(startTransactionStub.called).to.be.false;
+    expect(commitTransactionStub.called).to.be.false;
+  });
+
+  it("Should commit transaction when no external transaction is supplied", async () => {
+    await DAO.distributions.add({ distribution: customSplitDistribution });
+
+    expect(startTransactionStub.calledOnce).to.be.true;
+    expect(commitTransactionStub.calledOnce).to.be.true;
+  });
+
+  it("Should rollback on error when no external transaction is supplied", async () => {
+    transactionQueryStub.onFirstCall().rejects(new Error("DB error"));
+
+    try {
+      await DAO.distributions.add({ distribution: customSplitDistribution });
+      expect.fail("Should have thrown");
+    } catch (ex) {
+      expect(startTransactionStub.calledOnce).to.be.true;
+      expect(commitTransactionStub.called).to.be.false;
+      expect(rollbackTransactionStub.calledOnce).to.be.true;
+    }
+  });
+
+  it("Should not rollback on error when external transaction is supplied", async () => {
+    const externalTransaction = { query: sinon.stub() } as any;
+    externalTransaction.query.onFirstCall().rejects(new Error("DB error"));
+
+    try {
+      await DAO.distributions.add({
+        distribution: customSplitDistribution,
+        transaction: externalTransaction,
+      });
+      expect.fail("Should have thrown");
+    } catch (ex) {
+      expect(startTransactionStub.called).to.be.false;
+      expect(rollbackTransactionStub.called).to.be.false;
+    }
+  });
+});

--- a/src/__test__/DAO/distributions.spec.ts
+++ b/src/__test__/DAO/distributions.spec.ts
@@ -4,123 +4,77 @@ import { DAO } from "../../custom_modules/DAO";
 
 describe("DAO Distributions", () => {
   describe("getAll", () => {
+    const mockActiveOrgs = [{ abbriv: "AMF" }, { abbriv: "GW" }];
+
+    const mockResultRows = [
+      {
+        KID: "123456789",
+        full_name: "Test Testesen",
+        email: "testæøå@test.com",
+        donation_sum: 100,
+        donation_count: 2,
+        total_rows: 2,
+        AMF: "50.000000",
+        GW: "50.000000",
+      },
+      {
+        KID: "987654321",
+        full_name: "Test Testesen",
+        email: "testæøå@test.com",
+        donation_sum: 200,
+        donation_count: 1,
+        total_rows: 2,
+        AMF: "100.000000",
+        GW: "0.000000",
+      },
+    ];
+
     it("Gets all distributions with no filter", async () => {
       const queryStub = sinon.stub(DAO, "query");
 
-      const mockQueryResponse = [
-        {
-          KID: "123456789",
-          sum: 100,
-          count: 2,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-        {
-          KID: "987654321",
-          sum: 200,
-          count: 1,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-      ];
+      // First call: active orgs query; second call: main query
+      queryStub.onFirstCall().resolves([mockActiveOrgs, []]);
+      queryStub.onSecondCall().resolves([mockResultRows, []]);
 
-      const mockCountQueryResponse = [
-        {
-          count: 2,
-        },
-      ];
-
-      queryStub.onFirstCall().resolves([mockQueryResponse, []]);
-      queryStub.onSecondCall().resolves([mockCountQueryResponse, []]);
-
-      const result = await DAO.distributions.getAll(0, 10, { id: "ID" }, null);
+      const result = await DAO.distributions.getAll(0, 10, { id: "KID" }, null);
 
       expect(queryStub.calledTwice).to.be.true;
-      expect(result).to.deep.equal({
-        rows: mockQueryResponse,
-        pages: 1,
-      });
-      expect(queryStub.firstCall.args[0]).to.not.contain("WHERE");
-      expect(queryStub.firstCall.args[0]).to.contain("LIMIT 10");
-      expect(queryStub.firstCall.args[0]).to.contain("OFFSET 0");
+      expect(result.rows).to.have.length(2);
+      expect(result.rows[0].KID).to.equal("123456789");
+      expect(result.pages).to.equal(1);
+      // No donor/KID filter in the FilteredDistributions CTE
+      expect(queryStub.secondCall.args[0]).to.not.contain("full_name LIKE");
+      expect(queryStub.secondCall.args[0]).to.contain("LIMIT 10");
+      expect(queryStub.secondCall.args[0]).to.contain("OFFSET 0");
     });
 
     it("Gets all distributions with filter", async () => {
       const queryStub = sinon.stub(DAO, "query");
 
-      const mockQueryResponse = [
-        {
-          KID: "123456789",
-          sum: 100,
-          count: 2,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-        {
-          KID: "987654321",
-          sum: 200,
-          count: 1,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-      ];
-
-      const mockCountQueryResponse = [
-        {
-          count: 2,
-        },
-      ];
-
-      queryStub.onFirstCall().resolves([mockQueryResponse, []]);
-      queryStub.onSecondCall().resolves([mockCountQueryResponse, []]);
+      queryStub.onFirstCall().resolves([mockActiveOrgs, []]);
+      queryStub.onSecondCall().resolves([mockResultRows, []]);
 
       const result = await DAO.distributions.getAll(
         0,
         10,
-        { id: "ID" },
+        { id: "KID" },
         { donor: "Test Testesen" },
       );
 
       expect(queryStub.calledTwice).to.be.true;
-      expect(result).to.deep.equal({
-        rows: mockQueryResponse,
-        pages: 1,
-      });
-      expect(queryStub.firstCall.args[0]).to.contain("WHERE");
-      expect(queryStub.firstCall.args[0]).to.contain("Test Testesen");
-      expect(queryStub.firstCall.args[0]).to.contain("LIKE");
-      expect(queryStub.firstCall.args[0]).to.contain("LIMIT 10");
-      expect(queryStub.firstCall.args[0]).to.contain("OFFSET 0");
+      expect(result.rows).to.have.length(2);
+      expect(queryStub.secondCall.args[0]).to.contain("WHERE");
+      expect(queryStub.secondCall.args[0]).to.contain("Test Testesen");
+      expect(queryStub.secondCall.args[0]).to.contain("LIKE");
+      expect(queryStub.secondCall.args[0]).to.contain("LIMIT 10");
+      expect(queryStub.secondCall.args[0]).to.contain("OFFSET 0");
     });
 
     it("Gets all distributions with filter and order", async () => {
       const queryStub = sinon.stub(DAO, "query");
 
-      const mockQueryResponse = [
-        {
-          KID: "123456789",
-          sum: 100,
-          count: 2,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-        {
-          KID: "987654321",
-          sum: 200,
-          count: 1,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-      ];
-
-      const mockCountQueryResponse = [
-        {
-          count: 2,
-        },
-      ];
-
-      queryStub.onFirstCall().resolves([mockQueryResponse, []]);
-      queryStub.onSecondCall().resolves([mockCountQueryResponse, []]);
+      queryStub.onFirstCall().resolves([mockActiveOrgs, []]);
+      queryStub.onSecondCall().resolves([mockResultRows, []]);
 
       const result = await DAO.distributions.getAll(
         0,
@@ -130,64 +84,55 @@ describe("DAO Distributions", () => {
       );
 
       expect(queryStub.calledTwice).to.be.true;
-      expect(result).to.deep.equal({
-        rows: mockQueryResponse,
-        pages: 1,
-      });
-      expect(queryStub.firstCall.args[0]).to.contain("WHERE");
-      expect(queryStub.firstCall.args[0]).to.contain("Test Testesen");
-      expect(queryStub.firstCall.args[0]).to.contain("LIKE");
-      expect(queryStub.firstCall.args[0]).to.contain("ORDER BY sum DESC");
-      expect(queryStub.firstCall.args[0]).to.contain("LIMIT 10");
-      expect(queryStub.firstCall.args[0]).to.contain("OFFSET 0");
+      expect(result.rows).to.have.length(2);
+      expect(queryStub.secondCall.args[0]).to.contain("WHERE");
+      expect(queryStub.secondCall.args[0]).to.contain("Test Testesen");
+      expect(queryStub.secondCall.args[0]).to.contain("LIKE");
+      expect(queryStub.secondCall.args[0]).to.contain("ORDER BY donation_sum DESC");
+      expect(queryStub.secondCall.args[0]).to.contain("LIMIT 10");
+      expect(queryStub.secondCall.args[0]).to.contain("OFFSET 0");
     });
 
     it("Gets all distributions with correct pages counter when there are more rows than the limit", async () => {
       const queryStub = sinon.stub(DAO, "query");
 
-      const mockQueryResponse = [
-        {
-          KID: "987654321",
-          sum: 200,
-          count: 1,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-        {
-          KID: "987654321",
-          sum: 200,
-          count: 1,
-          full_name: "Glor Gorgesen Testesen",
-          email: "asd@test.com",
-        },
-        {
-          KID: "987654321",
-          sum: 200,
-          count: 1,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
+      const threeRowResult = [
+        { ...mockResultRows[0], total_rows: 3 },
+        { ...mockResultRows[1], total_rows: 3 },
+        { ...mockResultRows[0], KID: "111111111", total_rows: 3 },
       ];
 
-      const mockCountQueryResponse = [
-        {
-          count: 3,
-        },
-      ];
+      queryStub.onFirstCall().resolves([mockActiveOrgs, []]);
+      queryStub.onSecondCall().resolves([threeRowResult, []]);
 
-      queryStub.onFirstCall().resolves([mockQueryResponse, []]);
-      queryStub.onSecondCall().resolves([mockCountQueryResponse, []]);
-
-      const result = await DAO.distributions.getAll(0, 1, { id: "ID" }, null);
+      const result = await DAO.distributions.getAll(0, 1, { id: "KID" }, null);
 
       expect(queryStub.calledTwice).to.be.true;
-      expect(result).to.deep.equal({
-        rows: mockQueryResponse,
-        pages: 3,
-      });
-      expect(queryStub.firstCall.args[0]).to.not.contain("WHERE");
-      expect(queryStub.firstCall.args[0]).to.contain("LIMIT 1");
-      expect(queryStub.firstCall.args[0]).to.contain("OFFSET 0");
+      expect(result.pages).to.equal(3);
+      expect(queryStub.secondCall.args[0]).to.not.contain("full_name LIKE");
+      expect(queryStub.secondCall.args[0]).to.contain("LIMIT 1");
+      expect(queryStub.secondCall.args[0]).to.contain("OFFSET 0");
+    });
+
+    it("Throws error for invalid sort column", async () => {
+      try {
+        await DAO.distributions.getAll(0, 10, { id: "INVALID" }, null);
+        expect.fail("Should have thrown");
+      } catch (ex) {
+        expect(ex.message).to.contain("Invalid sort column");
+      }
+    });
+
+    it("Returns empty result when no rows match", async () => {
+      const queryStub = sinon.stub(DAO, "query");
+
+      queryStub.onFirstCall().resolves([mockActiveOrgs, []]);
+      queryStub.onSecondCall().resolves([[], []]);
+
+      const result = await DAO.distributions.getAll(0, 10, { id: "KID" }, null);
+
+      expect(result.rows).to.have.length(0);
+      expect(result.pages).to.equal(0);
     });
 
     afterEach(() => {

--- a/src/__test__/tax.spec.ts
+++ b/src/__test__/tax.spec.ts
@@ -1,0 +1,269 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import { DAO } from "../custom_modules/DAO";
+import { donationHelpers } from "../custom_modules/donationHelpers";
+import { connectDonationsForFirstTaxUnit, setTaxUnitOnDistribution } from "../custom_modules/tax";
+import { Distribution } from "../schemas/types";
+
+describe("tax", () => {
+  const tcfDistribution: Distribution = {
+    kid: "000000001",
+    donorId: 1,
+    taxUnitId: null,
+    causeAreas: [
+      {
+        id: 1,
+        standardSplit: true,
+        percentageShare: "100",
+        organizations: [
+          {
+            id: 12,
+            percentageShare: "100",
+          },
+        ],
+      },
+    ],
+  };
+
+  const customDistribution: Distribution = {
+    kid: "000000002",
+    donorId: 1,
+    taxUnitId: null,
+    causeAreas: [
+      {
+        id: 1,
+        standardSplit: false,
+        percentageShare: "100",
+        organizations: [
+          {
+            id: 1,
+            percentageShare: "60",
+          },
+          {
+            id: 2,
+            percentageShare: "40",
+          },
+        ],
+      },
+    ],
+  };
+
+  const fundraiserDistribution: Distribution = {
+    kid: "000000003",
+    donorId: 1,
+    taxUnitId: null,
+    fundraiserTransactionId: 42,
+    causeAreas: [
+      {
+        id: 1,
+        standardSplit: false,
+        percentageShare: "100",
+        organizations: [
+          {
+            id: 1,
+            percentageShare: "100",
+          },
+        ],
+      },
+    ],
+  };
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("connectDonationsForFirstTaxUnit", () => {
+    let distributionsAddStub: sinon.SinonStub;
+    let createKIDStub: sinon.SinonStub;
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers(new Date("2025-06-15").getTime());
+
+      sinon.stub(DAO.distributions, "getAllByDonor").resolves({
+        distributions: [tcfDistribution, customDistribution, fundraiserDistribution],
+      } as any);
+      sinon.stub(DAO.distributions, "connectFirstTaxUnit").resolves();
+      distributionsAddStub = sinon.stub(DAO.distributions, "add").resolves(true);
+      sinon.stub(DAO.donations, "updateKIDBeforeTimestamp").resolves();
+
+      createKIDStub = sinon.stub(donationHelpers, "createKID");
+      createKIDStub.onFirstCall().resolves("NEW_KID_001");
+      createKIDStub.onSecondCall().resolves("NEW_KID_002");
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it("Should create replacement distributions for donations before current year", async () => {
+      sinon.stub(DAO.donations, "getByDonorId").resolves([
+        { KID: "000000001", timestamp: "2024-03-15T00:00:00.000Z" },
+        { KID: "000000002", timestamp: "2024-06-01T00:00:00.000Z" },
+      ] as any);
+
+      await connectDonationsForFirstTaxUnit(1, 99);
+
+      expect(distributionsAddStub.calledTwice).to.be.true;
+    });
+
+    it("Should not create replacements for donations in the current year", async () => {
+      sinon
+        .stub(DAO.donations, "getByDonorId")
+        .resolves([{ KID: "000000001", timestamp: "2025-03-15T00:00:00.000Z" }] as any);
+
+      await connectDonationsForFirstTaxUnit(1, 99);
+
+      expect(distributionsAddStub.called).to.be.false;
+    });
+
+    it("Should pass preserveOrganizations: true when adding replacement distributions", async () => {
+      sinon
+        .stub(DAO.donations, "getByDonorId")
+        .resolves([{ KID: "000000001", timestamp: "2024-03-15T00:00:00.000Z" }] as any);
+
+      await connectDonationsForFirstTaxUnit(1, 99);
+
+      expect(distributionsAddStub.calledOnce).to.be.true;
+      const addArgs = distributionsAddStub.firstCall.args[0];
+      expect(addArgs.preserveOrganizations).to.be.true;
+    });
+
+    it("Should preserve original organizations in the replacement distribution", async () => {
+      sinon
+        .stub(DAO.donations, "getByDonorId")
+        .resolves([{ KID: "000000001", timestamp: "2024-03-15T00:00:00.000Z" }] as any);
+
+      await connectDonationsForFirstTaxUnit(1, 99);
+
+      const addArgs = distributionsAddStub.firstCall.args[0];
+      const distribution = addArgs.distribution;
+      // Should keep the original TCF org (id 12), not re-resolve to current standard
+      expect(distribution.causeAreas[0].organizations[0].id).to.equal(12);
+      expect(distribution.causeAreas[0].standardSplit).to.be.true;
+    });
+
+    it("Should use a new KID for the replacement distribution", async () => {
+      sinon
+        .stub(DAO.donations, "getByDonorId")
+        .resolves([{ KID: "000000001", timestamp: "2024-03-15T00:00:00.000Z" }] as any);
+
+      await connectDonationsForFirstTaxUnit(1, 99);
+
+      const addArgs = distributionsAddStub.firstCall.args[0];
+      expect(addArgs.distribution.kid).to.equal("NEW_KID_001");
+    });
+
+    it("Should skip fundraiser distributions", async () => {
+      sinon
+        .stub(DAO.donations, "getByDonorId")
+        .resolves([{ KID: "000000003", timestamp: "2024-03-15T00:00:00.000Z" }] as any);
+
+      await connectDonationsForFirstTaxUnit(1, 99);
+
+      expect(distributionsAddStub.called).to.be.false;
+    });
+
+    it("Should handle multiple old donations with the same KID", async () => {
+      sinon.stub(DAO.donations, "getByDonorId").resolves([
+        { KID: "000000001", timestamp: "2024-01-15T00:00:00.000Z" },
+        { KID: "000000001", timestamp: "2024-06-15T00:00:00.000Z" },
+      ] as any);
+
+      await connectDonationsForFirstTaxUnit(1, 99);
+
+      // Should only create one replacement, since both donations share the same KID
+      expect(distributionsAddStub.calledOnce).to.be.true;
+    });
+  });
+
+  describe("setTaxUnitOnDistribution", () => {
+    let distributionsAddStub: sinon.SinonStub;
+    let addTaxUnitStub: sinon.SinonStub;
+    let createKIDStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      sinon.useFakeTimers(new Date("2025-06-15").getTime());
+
+      distributionsAddStub = sinon.stub(DAO.distributions, "add").resolves(true);
+      addTaxUnitStub = sinon.stub(DAO.distributions, "addTaxUnitToDistribution").resolves();
+      sinon.stub(DAO.donations, "updateKIDBeforeTimestamp").resolves();
+
+      createKIDStub = sinon.stub(donationHelpers, "createKID").resolves("NEW_KID_001");
+    });
+
+    it("Should throw if distribution is not found", async () => {
+      sinon.stub(DAO.distributions, "getSplitByKID").resolves(null);
+
+      try {
+        await setTaxUnitOnDistribution("000000001", 99);
+        expect.fail("Should have thrown");
+      } catch (ex) {
+        expect(ex.message).to.equal("Distribution not found");
+      }
+    });
+
+    it("Should throw if distribution already has a tax unit", async () => {
+      sinon.stub(DAO.distributions, "getSplitByKID").resolves({
+        ...tcfDistribution,
+        taxUnitId: 50,
+      });
+
+      try {
+        await setTaxUnitOnDistribution("000000001", 99);
+        expect.fail("Should have thrown");
+      } catch (ex) {
+        expect(ex.message).to.equal("Distribution already has a tax unit");
+      }
+    });
+
+    it("Should handle fundraiser distributions by setting tax unit directly", async () => {
+      sinon.stub(DAO.distributions, "getSplitByKID").resolves(fundraiserDistribution);
+
+      await setTaxUnitOnDistribution("000000003", 99);
+
+      expect(addTaxUnitStub.calledOnce).to.be.true;
+      expect(addTaxUnitStub.firstCall.args).to.deep.equal(["000000003", 99]);
+      expect(distributionsAddStub.called).to.be.false;
+    });
+
+    it("Should pass preserveOrganizations: true when creating duplicate distribution", async () => {
+      sinon.stub(DAO.distributions, "getSplitByKID").resolves(tcfDistribution);
+
+      await setTaxUnitOnDistribution("000000001", 99);
+
+      expect(distributionsAddStub.calledOnce).to.be.true;
+      const addArgs = distributionsAddStub.firstCall.args[0];
+      expect(addArgs.preserveOrganizations).to.be.true;
+    });
+
+    it("Should preserve original organizations in the duplicate distribution", async () => {
+      sinon.stub(DAO.distributions, "getSplitByKID").resolves(tcfDistribution);
+
+      await setTaxUnitOnDistribution("000000001", 99);
+
+      const addArgs = distributionsAddStub.firstCall.args[0];
+      const distribution = addArgs.distribution;
+      expect(distribution.causeAreas[0].organizations[0].id).to.equal(12);
+      expect(distribution.causeAreas[0].standardSplit).to.be.true;
+    });
+
+    it("Should set tax unit on the original distribution after creating duplicate", async () => {
+      sinon.stub(DAO.distributions, "getSplitByKID").resolves(tcfDistribution);
+
+      await setTaxUnitOnDistribution("000000001", 99);
+
+      expect(addTaxUnitStub.calledOnce).to.be.true;
+      expect(addTaxUnitStub.firstCall.args).to.deep.equal(["000000001", 99]);
+    });
+
+    it("Should use new KID for the duplicate distribution", async () => {
+      sinon.stub(DAO.distributions, "getSplitByKID").resolves(tcfDistribution);
+
+      await setTaxUnitOnDistribution("000000001", 99);
+
+      const addArgs = distributionsAddStub.firstCall.args[0];
+      expect(addArgs.distribution.kid).to.equal("NEW_KID_001");
+    });
+  });
+});

--- a/src/custom_modules/DAO_modules/autogiroagreements.ts
+++ b/src/custom_modules/DAO_modules/autogiroagreements.ts
@@ -314,14 +314,14 @@ export const autogiroagreements = {
       ]);
 
       // Add new distribution using the original KID
-      await DAO.distributions.add(
-        {
+      await DAO.distributions.add({
+        distribution: {
           ...newDistributionInput,
           kid: originalDistribution.kid,
         },
         metaOwnerID,
         transaction,
-      );
+      });
 
       // Links the replacement KID to the original AutoGiro KID
       await transaction.query(

--- a/src/custom_modules/DAO_modules/avtalegiroagreements.ts
+++ b/src/custom_modules/DAO_modules/avtalegiroagreements.ts
@@ -157,14 +157,14 @@ async function replaceDistribution(
     ]);
 
     // Add new distribution using the original KID
-    await DAO.distributions.add(
-      {
+    await DAO.distributions.add({
+      distribution: {
         ...newDistributionInput,
         kid: originalDistribution.kid,
       },
       metaOwnerID,
       transaction,
-    );
+    });
 
     // Links the replacement KID to the original AvtaleGiro KID
     await transaction.query(

--- a/src/custom_modules/DAO_modules/distributions.ts
+++ b/src/custom_modules/DAO_modules/distributions.ts
@@ -621,13 +621,17 @@ async function getKIDsByPrefix(prefix: string): Promise<string[]> {
  * @param {number} metaOwnerID Optional meta owner ID, specifies who is the owner of the data
  * @return {boolean} Returns true if the distribution was added successfully, throws if fails
  */
-async function add(
-  distribution: Distribution,
-  metaOwnerID: number | null = null,
-  suppliedTransaction?: PoolConnection,
-): Promise<boolean> {
+async function add(args: {
+  distribution: Distribution;
+  metaOwnerID?: number | null;
+  transaction?: PoolConnection;
+  preserveOrganizations?: boolean;
+}): Promise<boolean> {
+  const { distribution, transaction: suppliedTransaction, preserveOrganizations = false } = args;
+
   try {
     var transaction = suppliedTransaction ?? (await DAO.startTransaction());
+    var metaOwnerID = args.metaOwnerID ?? null;
 
     if (metaOwnerID == null) {
       metaOwnerID = await DAO.meta.getDefaultOwnerID();
@@ -683,7 +687,7 @@ async function add(
       if (!causeArea) {
         throw new Error("Could not find cause area");
       }
-      if (!causeArea.standardSplit) {
+      if (!causeArea.standardSplit || preserveOrganizations) {
         const orgs = causeArea.organizations;
         for (const org of orgs) {
           distributionCauseAreaOrganizationInsertsRowValues.push([

--- a/src/custom_modules/adoveo.ts
+++ b/src/custom_modules/adoveo.ts
@@ -616,10 +616,12 @@ async function getKID(causeAreas: DistributionCauseArea[], donorId: number, taxU
     const newKID = await donationHelpers.createKID();
     console.log("New KID", newKID);
     await DAO.distributions.add({
-      kid: newKID,
-      donorId,
-      taxUnitId,
-      causeAreas,
+      distribution: {
+        kid: newKID,
+        donorId,
+        taxUnitId,
+        causeAreas,
+      },
     });
     KID = newKID;
   }

--- a/src/custom_modules/amf.ts
+++ b/src/custom_modules/amf.ts
@@ -81,10 +81,10 @@ export const processAmfDonations = async (report: Buffer) => {
     let donationKID = await DAO.distributions.getKIDbySplit(distributionInput);
     if (!donationKID) {
       donationKID = await KID.generate();
-      const success = await DAO.distributions.add(
-        { ...distributionInput, kid: donationKID },
-        EFFEKT_FOUNDATION_META_OWNER_ID,
-      );
+      const success = await DAO.distributions.add({
+        distribution: { ...distributionInput, kid: donationKID },
+        metaOwnerID: EFFEKT_FOUNDATION_META_OWNER_ID,
+      });
       if (!success) {
         console.error(
           `Failed to add distribution for transaction ${transaction.number} with KID ${donationKID}`,

--- a/src/custom_modules/import.ts
+++ b/src/custom_modules/import.ts
@@ -131,8 +131,10 @@ export const importSwedishDonationsReport = async (report, medgivandeReport) => 
           KID = trimmedReferenceNumber;
 
           await DAO.distributions.add({
-            ...distributionInput,
-            kid: KID,
+            distribution: {
+              ...distributionInput,
+              kid: KID,
+            },
           });
           // console.log("Added distribution for KID", KID)
         } else {
@@ -149,8 +151,10 @@ export const importSwedishDonationsReport = async (report, medgivandeReport) => 
             const existing = await DAO.distributions.getSplitByKID(KID);
             if (!existing) {
               await DAO.distributions.add({
-                ...distributionInput,
-                kid: KID,
+                distribution: {
+                  ...distributionInput,
+                  kid: KID,
+                },
               });
               // console.log("Added distribution for KID", KID)
             }
@@ -169,8 +173,10 @@ export const importSwedishDonationsReport = async (report, medgivandeReport) => 
         // console.log(`Creating a new KID`)
         let newKID = await donationHelpers.createKID();
         await DAO.distributions.add({
-          ...distributionInput,
-          kid: newKID,
+          distribution: {
+            ...distributionInput,
+            kid: newKID,
+          },
         });
         KID = newKID;
       }

--- a/src/custom_modules/tax.ts
+++ b/src/custom_modules/tax.ts
@@ -50,7 +50,7 @@ export async function connectDonationsForFirstTaxUnit(donorId: number, taxUnitId
       kid: replacementKID,
     };
 
-    await DAO.distributions.add(newDistribution);
+    await DAO.distributions.add({ distribution: newDistribution, preserveOrganizations: true });
 
     /**
      * Then we update the donations from before the current year to use the new KID
@@ -88,7 +88,7 @@ export async function setTaxUnitOnDistribution(kid: string, taxUnitId: number) {
   newDistribution.kid = newKID;
 
   // Add the new distribution
-  await DAO.distributions.add(newDistribution);
+  await DAO.distributions.add({ distribution: newDistribution, preserveOrganizations: true });
 
   // Update the donations to use the new KID
   const previousYearStart = DateTime.now().minus({ years: 1 }).startOf("year");

--- a/src/routes/distributions.ts
+++ b/src/routes/distributions.ts
@@ -31,8 +31,10 @@ router.post("/", authMiddleware.isAdmin, async (req, res, next) => {
     const KID = await donationHelpers.createKID();
 
     await DAO.distributions.add({
-      kid: KID,
-      ...validatedDistribution,
+      distribution: {
+        kid: KID,
+        ...validatedDistribution,
+      },
     });
 
     res.json({

--- a/src/routes/donations.ts
+++ b/src/routes/donations.ts
@@ -191,8 +191,10 @@ router.post("/register", async (req, res, next) => {
       //Create unique KID for each AvtaleGiro to prevent duplicates causing conflicts
       donationObject.KID = await donationHelpers.createAvtaleGiroKID();
       await DAO.distributions.add({
-        ...draftDistribution,
-        kid: donationObject.KID,
+        distribution: {
+          ...draftDistribution,
+          kid: donationObject.KID,
+        },
       });
     } else if (donationObject.method == methods.AUTOGIRO) {
       if (fundraiser) {
@@ -201,8 +203,10 @@ router.post("/register", async (req, res, next) => {
 
       donationObject.KID = await donationHelpers.createKID(8);
       await DAO.distributions.add({
-        ...draftDistribution,
-        kid: donationObject.KID,
+        distribution: {
+          ...draftDistribution,
+          kid: donationObject.KID,
+        },
       });
 
       // Draft AutoGiro
@@ -255,7 +259,7 @@ router.post("/register", async (req, res, next) => {
           ...draftDistribution,
         };
 
-        await DAO.distributions.add(distribution);
+        await DAO.distributions.add({ distribution });
       }
     }
 
@@ -369,9 +373,11 @@ router.put("/:id", authMiddleware.isAdmin, async (req, res, next) => {
           // Create a new KID and distribution
           const newKid = await donationHelpers.createKID();
           await DAO.distributions.add({
-            ...validatedDistribution,
-            // Overwrite the KID with the new one
-            kid: newKid,
+            distribution: {
+              ...validatedDistribution,
+              // Overwrite the KID with the new one
+              kid: newKid,
+            },
           });
           await DAO.donations.updateKIDById(req.params.id, newKid);
         }

--- a/src/routes/vipps.ts
+++ b/src/routes/vipps.ts
@@ -673,7 +673,7 @@ router.put("/agreement/:urlcode/distribution", jsonBody, async (req, res, next) 
       KID = existingDistributionKID;
     } else {
       KID = await donationHelpers.createKID();
-      await DAO.distributions.add({ ...validatedDistribution, kid: KID });
+      await DAO.distributions.add({ distribution: { ...validatedDistribution, kid: KID } });
     }
 
     const response = await DAO.vipps.updateAgreementKID(agreementId, KID);


### PR DESCRIPTION
When connecting a donor's first tax unit, old donations were moved to new distribution copies via distributions.add(). For standardSplit: true distributions, add() re-resolved organizations from the DB (now AGF) instead of preserving the original orgs (TCF).

Refactors distributions.add() to use a keyed options object and adds a preserveOrganizations flag that bypasses standard split re-resolution. Updates all call sites. Fixes pre-existing test failures in distributions.spec.ts and adds comprehensive tests for the new behavior.

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
