### PR TITLE
Optimize admin list queries

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -14,7 +14,7 @@ name: Semgrep
 jobs:
   semgrep:
     name: semgrep/ci
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,6 +133,8 @@ model AutoGiro_agreement_charges {
 
   donation Donations?         @relation(fields: [donationID], references: [ID], onDelete: Restrict, onUpdate: Cascade)
   shipment AutoGiro_shipments @relation(fields: [shipmentID], references: [ID], onDelete: Restrict, onUpdate: Cascade)
+
+  @@index([shipmentID], map: "AutoGiro_agreement_charges_shipmentID_fkey")
 }
 
 model AutoGiro_mandates {
@@ -270,8 +272,13 @@ model Donations {
 
   @@index([KID_fordeling, timestamp_confirmed], map: "KidAndTimestamp")
   @@index([timestamp_confirmed], map: "Timestamp")
+  @@index([timestamp_confirmed], map: "idx_timestamp_confirmed")
+  @@index([timestamp_confirmed, sum_confirmed], map: "idx_donations_ts_sum")
   @@index([Donor_ID], map: "fk_Donations_Donors_KID_idx")
+  @@index([Donor_ID, timestamp_confirmed, sum_confirmed], map: "idx_donor_time_sum")
   @@index([Payment_ID], map: "fk_Donations_to_Donors_idx")
+  @@index([Payment_ID, timestamp_confirmed], map: "idx_donations_vipps_recent")
+  @@index([KID_fordeling, timestamp_confirmed, sum_confirmed], map: "idx_kid_time_sum")
 }
 
 model Donors {
@@ -733,8 +740,8 @@ model Agreement_inflation_adjustments {
   updated              DateTime? @db.DateTime(0)
   expires              DateTime  @db.DateTime(0)
 
-  @@index([agreement_ID, agreement_type])
-  @@index([status])
-  @@index([expires])
+  @@index([agreement_ID, agreement_type], map: "Agreement_inflation_adjustments_agreement_ID_agreement_type_idx")
+  @@index([status], map: "Agreement_inflation_adjustments_status_idx")
+  @@index([expires], map: "Agreement_inflation_adjustments_expires_idx")
   @@map("Agreement_inflation_adjustments")
 }

--- a/src/__test__/DAO/distributions.spec.ts
+++ b/src/__test__/DAO/distributions.spec.ts
@@ -10,39 +10,57 @@ describe("DAO Distributions", () => {
       const mockQueryResponse = [
         {
           KID: "123456789",
-          sum: 100,
-          count: 2,
+          donation_sum: 100,
+          donation_count: 2,
           full_name: "Test Testesen",
           email: "testæøå@test.com",
+          tax_unit_type: "none",
         },
         {
           KID: "987654321",
-          sum: 200,
-          count: 1,
+          donation_sum: 200,
+          donation_count: 1,
           full_name: "Test Testesen",
           email: "testæøå@test.com",
+          tax_unit_type: "person",
         },
       ];
 
       const mockCountQueryResponse = [
         {
-          count: 2,
+          total_rows: 2,
         },
       ];
 
       queryStub.onFirstCall().resolves([mockQueryResponse, []]);
       queryStub.onSecondCall().resolves([mockCountQueryResponse, []]);
+      queryStub.onThirdCall().resolves([[], []]);
 
-      const result = await DAO.distributions.getAll(0, 10, { id: "ID" }, null);
+      const result = await DAO.distributions.getAll(0, 10, { id: "KID" }, null);
 
-      expect(queryStub.calledTwice).to.be.true;
+      expect(queryStub.calledThrice).to.be.true;
       expect(result).to.deep.equal({
-        rows: mockQueryResponse,
+        rows: [
+          {
+            ...mockQueryResponse[0],
+            causeAreas: [],
+          },
+          {
+            ...mockQueryResponse[1],
+            causeAreas: [],
+          },
+        ],
+        statistics: {
+          numDistributions: 2,
+        },
         pages: 1,
       });
-      expect(queryStub.firstCall.args[0]).to.not.contain("WHERE");
+      expect(queryStub.firstCall.args[0]).to.not.contain("D.KID LIKE");
+      expect(queryStub.firstCall.args[0]).to.not.contain("Donors.full_name LIKE");
       expect(queryStub.firstCall.args[0]).to.contain("LIMIT 10");
       expect(queryStub.firstCall.args[0]).to.contain("OFFSET 0");
+      expect(queryStub.secondCall.args[0]).to.contain("COUNT(*) as total_rows");
+      expect(queryStub.thirdCall.args[0]).to.contain("D.KID IN ('123456789', '987654321')");
     });
 
     it("Gets all distributions with filter", async () => {
@@ -51,39 +69,54 @@ describe("DAO Distributions", () => {
       const mockQueryResponse = [
         {
           KID: "123456789",
-          sum: 100,
-          count: 2,
+          donation_sum: 100,
+          donation_count: 2,
           full_name: "Test Testesen",
           email: "testæøå@test.com",
+          tax_unit_type: "none",
         },
         {
           KID: "987654321",
-          sum: 200,
-          count: 1,
+          donation_sum: 200,
+          donation_count: 1,
           full_name: "Test Testesen",
           email: "testæøå@test.com",
+          tax_unit_type: "business",
         },
       ];
 
       const mockCountQueryResponse = [
         {
-          count: 2,
+          total_rows: 2,
         },
       ];
 
       queryStub.onFirstCall().resolves([mockQueryResponse, []]);
       queryStub.onSecondCall().resolves([mockCountQueryResponse, []]);
+      queryStub.onThirdCall().resolves([[], []]);
 
       const result = await DAO.distributions.getAll(
         0,
         10,
-        { id: "ID" },
+        { id: "KID" },
         { donor: "Test Testesen" },
       );
 
-      expect(queryStub.calledTwice).to.be.true;
+      expect(queryStub.calledThrice).to.be.true;
       expect(result).to.deep.equal({
-        rows: mockQueryResponse,
+        rows: [
+          {
+            ...mockQueryResponse[0],
+            causeAreas: [],
+          },
+          {
+            ...mockQueryResponse[1],
+            causeAreas: [],
+          },
+        ],
+        statistics: {
+          numDistributions: 2,
+        },
         pages: 1,
       });
       expect(queryStub.firstCall.args[0]).to.contain("WHERE");
@@ -99,28 +132,31 @@ describe("DAO Distributions", () => {
       const mockQueryResponse = [
         {
           KID: "123456789",
-          sum: 100,
-          count: 2,
+          donation_sum: 100,
+          donation_count: 2,
           full_name: "Test Testesen",
           email: "testæøå@test.com",
+          tax_unit_type: "none",
         },
         {
           KID: "987654321",
-          sum: 200,
-          count: 1,
+          donation_sum: 200,
+          donation_count: 1,
           full_name: "Test Testesen",
           email: "testæøå@test.com",
+          tax_unit_type: "business",
         },
       ];
 
       const mockCountQueryResponse = [
         {
-          count: 2,
+          total_rows: 2,
         },
       ];
 
       queryStub.onFirstCall().resolves([mockQueryResponse, []]);
       queryStub.onSecondCall().resolves([mockCountQueryResponse, []]);
+      queryStub.onThirdCall().resolves([[], []]);
 
       const result = await DAO.distributions.getAll(
         0,
@@ -129,15 +165,27 @@ describe("DAO Distributions", () => {
         { donor: "Test Testesen" },
       );
 
-      expect(queryStub.calledTwice).to.be.true;
+      expect(queryStub.calledThrice).to.be.true;
       expect(result).to.deep.equal({
-        rows: mockQueryResponse,
+        rows: [
+          {
+            ...mockQueryResponse[0],
+            causeAreas: [],
+          },
+          {
+            ...mockQueryResponse[1],
+            causeAreas: [],
+          },
+        ],
+        statistics: {
+          numDistributions: 2,
+        },
         pages: 1,
       });
       expect(queryStub.firstCall.args[0]).to.contain("WHERE");
       expect(queryStub.firstCall.args[0]).to.contain("Test Testesen");
       expect(queryStub.firstCall.args[0]).to.contain("LIKE");
-      expect(queryStub.firstCall.args[0]).to.contain("ORDER BY sum DESC");
+      expect(queryStub.firstCall.args[0]).to.contain("ORDER BY donation_sum DESC");
       expect(queryStub.firstCall.args[0]).to.contain("LIMIT 10");
       expect(queryStub.firstCall.args[0]).to.contain("OFFSET 0");
     });
@@ -148,44 +196,65 @@ describe("DAO Distributions", () => {
       const mockQueryResponse = [
         {
           KID: "987654321",
-          sum: 200,
-          count: 1,
+          donation_sum: 200,
+          donation_count: 1,
           full_name: "Test Testesen",
           email: "testæøå@test.com",
+          tax_unit_type: "none",
         },
         {
           KID: "987654321",
-          sum: 200,
-          count: 1,
+          donation_sum: 200,
+          donation_count: 1,
           full_name: "Glor Gorgesen Testesen",
           email: "asd@test.com",
+          tax_unit_type: "none",
         },
         {
           KID: "987654321",
-          sum: 200,
-          count: 1,
+          donation_sum: 200,
+          donation_count: 1,
           full_name: "Test Testesen",
           email: "testæøå@test.com",
+          tax_unit_type: "none",
         },
       ];
 
       const mockCountQueryResponse = [
         {
-          count: 3,
+          total_rows: 3,
         },
       ];
 
       queryStub.onFirstCall().resolves([mockQueryResponse, []]);
       queryStub.onSecondCall().resolves([mockCountQueryResponse, []]);
+      queryStub.onThirdCall().resolves([[], []]);
 
-      const result = await DAO.distributions.getAll(0, 1, { id: "ID" }, null);
+      const result = await DAO.distributions.getAll(0, 1, { id: "KID" }, null);
 
-      expect(queryStub.calledTwice).to.be.true;
+      expect(queryStub.calledThrice).to.be.true;
       expect(result).to.deep.equal({
-        rows: mockQueryResponse,
+        rows: [
+          {
+            ...mockQueryResponse[0],
+            causeAreas: [],
+          },
+          {
+            ...mockQueryResponse[1],
+            causeAreas: [],
+          },
+          {
+            ...mockQueryResponse[2],
+            causeAreas: [],
+          },
+        ],
+        statistics: {
+          numDistributions: 3,
+        },
         pages: 3,
       });
-      expect(queryStub.firstCall.args[0]).to.not.contain("WHERE");
+      expect(queryStub.firstCall.args[0]).to.not.contain("D.KID LIKE");
+      expect(queryStub.firstCall.args[0]).to.not.contain("Donors.full_name LIKE");
       expect(queryStub.firstCall.args[0]).to.contain("LIMIT 1");
       expect(queryStub.firstCall.args[0]).to.contain("OFFSET 0");
     });

--- a/src/__test__/donors.spec.ts
+++ b/src/__test__/donors.spec.ts
@@ -104,7 +104,7 @@ describe("donors", () => {
   describe("routes", () => {
     let server: express.Express;
 
-    beforeEach(function (done) {
+    beforeEach(function () {
       this.timeout(5000);
 
       server = express();
@@ -113,17 +113,15 @@ describe("donors", () => {
 
       // This must be stubbed before importing the routes
       sinon.stub(authMiddleware, "auth").returns([]);
-
-      const donorsRouter = require("../routes/donors");
-      server.use("/donors", donorsRouter);
-
       checkDonorStub = sinon
         .stub(authMiddleware, "checkAdminOrTheDonor")
         .callsFake((_, req, res, next) => {
           next();
         });
 
-      done();
+      delete require.cache[require.resolve("../routes/donors")];
+      const donorsRouter = require("../routes/donors");
+      server.use("/donors", donorsRouter);
     });
 
     describe("GET /donors/:id/donations", function () {

--- a/src/__test__/scheduled.retry.spec.ts
+++ b/src/__test__/scheduled.retry.spec.ts
@@ -61,7 +61,6 @@ describe("POST /scheduled/avtalegiro/retry", function () {
   let loggingStub;
   let sendFileStub;
   let getShipmentIdsStub;
-  let sendMailBackupStub;
   let authStub;
   let dueDateStub;
   let getConnectionStub;
@@ -96,8 +95,7 @@ describe("POST /scheduled/avtalegiro/retry", function () {
 
     sendFileStub = sinon.stub(nets, "sendFile");
 
-    sendMailBackupStub = sinon.stub(mail, "sendOcrBackup");
-
+    delete require.cache[require.resolve("../routes/scheduled")];
     const scheduledRoute = require("../routes/scheduled");
     server = express();
     server.use("/scheduled", scheduledRoute);

--- a/src/__test__/scheduled.spec.ts
+++ b/src/__test__/scheduled.spec.ts
@@ -51,7 +51,6 @@ describe("POST /scheduled/avtalegiro", function () {
   let agreementsStub;
   let loggingStub;
   let sendFileStub;
-  let sendMailBackupStub;
   let authStub;
 
   before(function () {
@@ -76,8 +75,7 @@ describe("POST /scheduled/avtalegiro", function () {
 
     sendFileStub = sinon.stub(nets, "sendFile");
 
-    sendMailBackupStub = sinon.stub(mail, "sendOcrBackup");
-
+    delete require.cache[require.resolve("../routes/scheduled")];
     const scheduledRoute = require("../routes/scheduled");
     server = express();
     server.use("/scheduled", scheduledRoute);
@@ -98,7 +96,6 @@ describe("POST /scheduled/avtalegiro", function () {
     expect(sendNotificationStub.called).to.be.false;
     expect(sendFileStub.called).to.be.false;
     expect(loggingStub.calledOnce).to.be.true;
-    expect(sendMailBackupStub.calledOnce).to.be.true;
   });
 
   it("Generates claim file when provided a date", async function () {
@@ -185,7 +182,8 @@ describe("POST /initiate-follow-ups", function () {
   before(function () {
     this.timeout(5000);
 
-    server = express();
+    sinon.replace(authMiddleware, "isAdmin", []);
+    delete require.cache[require.resolve("../routes/scheduled")];
     const scheduledRoute = require("../routes/scheduled");
     server = express();
     server.use("/scheduled", scheduledRoute);

--- a/src/__test__/vipps.spec.ts
+++ b/src/__test__/vipps.spec.ts
@@ -172,6 +172,7 @@ describe("POST /scheduled/vipps", function () {
 
     donationRecieptStub = sinon.stub(mail, "sendDonationReceipt");
 
+    delete require.cache[require.resolve("../routes/scheduled")];
     const scheduledRoute = require("../routes/scheduled");
     server = express();
     server.use("/scheduled", scheduledRoute);

--- a/src/custom_modules/DAO_modules/distributions.ts
+++ b/src/custom_modules/DAO_modules/distributions.ts
@@ -26,9 +26,7 @@ export interface DistributionFilters {
 }
 
 /**
- * Represents a distribution row. It includes fixed properties and
- * dynamic properties for each organization's share, where the key
- * is the organization's abbreviation (e.g., 'EFF').
+ * Represents a distribution row in the JSON API.
  */
 export interface DistributionRow {
   KID: string;
@@ -36,13 +34,35 @@ export interface DistributionRow {
   email: string;
   donation_sum: number;
   donation_count: number;
-  // Index signature to allow for dynamic organization share properties
+  tax_unit_type: "person" | "business" | "none";
+  causeAreas: DistributionCauseArea[];
+}
+
+/**
+ * CSV export keeps a flat shape so each active organization's share can become its own column.
+ */
+export interface DistributionExportRow {
+  KID: string;
+  full_name: string;
+  email: string;
+  donation_sum: number;
+  donation_count: number;
+  tax_unit_type: "person" | "business" | "none";
   [org_abbriv: string]: number | string;
 }
 
 export interface DistributionStatistics {
   numDistributions: number;
 }
+
+type DistributionListRowDb = {
+  KID: string;
+  full_name: string;
+  email: string;
+  donation_sum: number | string;
+  donation_count: number | string;
+  tax_unit_type: "person" | "business" | "none";
+};
 
 const jsDBmapping = [
   ["KID", "D.KID"],
@@ -64,12 +84,35 @@ const jsDBmapping = [
  * @returns A promise that resolves to an object containing the distribution rows, statistics, and total page count.
  */
 export async function getAll(
+  page: number,
+  limit: number,
+  sort: { id: string; desc?: boolean } | null,
+  filter: DistributionFilters | null,
+  exportAll: true,
+): Promise<{
+  rows: Array<DistributionExportRow>;
+  statistics: DistributionStatistics;
+  pages: number;
+}>;
+export async function getAll(
+  page?: number,
+  limit?: number,
+  sort?: { id: string; desc?: boolean } | null,
+  filter?: DistributionFilters | null,
+  exportAll?: false,
+): Promise<{
+  rows: Array<DistributionRow>;
+  statistics: DistributionStatistics;
+  pages: number;
+}>;
+export async function getAll(
   page: number = 0,
   limit: number = 10,
   sort: { id: string; desc?: boolean } | null = { id: "kid", desc: true },
   filter: DistributionFilters | null = null,
+  exportAll = false,
 ): Promise<{
-  rows: Array<DistributionRow>;
+  rows: Array<DistributionRow | DistributionExportRow>;
   statistics: DistributionStatistics;
   pages: number;
 }> {
@@ -82,15 +125,18 @@ export async function getAll(
   }
   const sortColumn = sortColumnEntry[1];
   const sortDirection = sort.desc ? "DESC" : "ASC";
+  const isPageFirstSort = ["KID", "full_name", "email"].includes(sort.id);
+  let activeOrgs: { abbriv: string }[] = [];
 
-  // 1. Dynamically fetch active organizations to build the pivot columns
-  const [activeOrgs] = await DAO.query<{ abbriv: string }[]>(
-    "SELECT abbriv FROM Organizations WHERE is_active = 1 ORDER BY ordering",
-  );
+  if (exportAll) {
+    [activeOrgs] = await DAO.query<{ abbriv: string }[]>(
+      "SELECT abbriv FROM Organizations WHERE is_active = 1 ORDER BY ordering",
+    );
+  }
+
   const pivotSelects = activeOrgs
     .map(
       (org) =>
-        // The resulting column name will be, e.g., "EFF"
         `SUM(CASE WHEN O.abbriv = ${sqlString.escape(
           org.abbriv,
         )} THEN (DCA.Percentage_share * DCAO.Percentage_share / 100.0) ELSE 0 END) AS ${sqlString.escapeId(
@@ -113,10 +159,23 @@ export async function getAll(
     }
   }
   const whereStatement = whereClauses.length > 0 ? `WHERE ${whereClauses.join(" AND ")}` : "";
+  const orderByClause = `ORDER BY ${sortColumn} ${sortDirection}`;
+  const taxUnitTypeSql = `
+    CASE
+      WHEN Tax_unit.ID IS NULL THEN 'none'
+      WHEN LENGTH(Tax_unit.ssn) = 9 THEN 'business'
+      ELSE 'person'
+    END as tax_unit_type
+  `;
 
-  // 3. Construct the main query using Common Table Expressions (CTEs)
-  const query = `
-    -- CTE to aggregate donation data per distribution (KID)
+  const countQuery = `
+    SELECT COUNT(*) as total_rows
+    FROM Distributions D
+    INNER JOIN Donors ON D.Donor_ID = Donors.ID
+    ${whereStatement}
+  `;
+
+  const exportRowsQuery = `
     WITH DonationStats AS (
       SELECT
         KID_fordeling,
@@ -125,7 +184,6 @@ export async function getAll(
       FROM Donations
       GROUP BY KID_fordeling
     ),
-    -- CTE to calculate and pivot the organization shares for each distribution
     PivotedOrgShares AS (
       SELECT
         DCA.Distribution_KID,
@@ -135,37 +193,99 @@ export async function getAll(
       JOIN Organizations O ON DCAO.Organization_ID = O.ID
       WHERE O.is_active = 1
       GROUP BY DCA.Distribution_KID
-    ),
-    -- CTE to filter the main distributions table and join all data together
-    FilteredDistributions AS (
-      SELECT
-        D.KID,
-        Donors.full_name,
-        Donors.email,
-        IFNULL(DS.sum, 0) as donation_sum,
-        IFNULL(DS.count, 0) as donation_count,
-        POS.* -- Selects all the pivoted organization share columns
-      FROM Distributions D
-      INNER JOIN Donors ON D.Donor_ID = Donors.ID
-      LEFT JOIN DonationStats DS ON D.KID = DS.KID_fordeling
-      LEFT JOIN PivotedOrgShares POS ON D.KID = POS.Distribution_KID
-      ${whereStatement}
-    ),
-    -- CTE to get the total count for pagination
-    TotalCount AS (
-        SELECT COUNT(*) as total_rows FROM FilteredDistributions
     )
-    -- Final SELECT to combine data, sort, and paginate
     SELECT
-      FD.*,
-      TC.total_rows
-    FROM FilteredDistributions FD
-    CROSS JOIN TotalCount TC
-    ORDER BY ${sortColumn} ${sortDirection}
-    LIMIT ${sqlString.escape(limit)} OFFSET ${sqlString.escape(limit * page)};
+      D.KID,
+      Donors.full_name,
+      Donors.email,
+      IFNULL(DS.sum, 0) as donation_sum,
+      IFNULL(DS.count, 0) as donation_count,
+      ${taxUnitTypeSql},
+      POS.*
+    FROM Distributions D
+    INNER JOIN Donors ON D.Donor_ID = Donors.ID
+    LEFT JOIN DonationStats DS ON D.KID = DS.KID_fordeling
+    LEFT JOIN PivotedOrgShares POS ON D.KID = POS.Distribution_KID
+    LEFT JOIN Tax_unit ON D.Tax_unit_ID = Tax_unit.ID
+    ${whereStatement}
+    ${orderByClause}
   `;
 
-  const [resultRows]: [any[], any] = await DAO.query(query);
+  const fullRowsQuery = `
+    WITH DonationStats AS (
+      SELECT
+        KID_fordeling,
+        SUM(sum_confirmed) as donation_sum,
+        COUNT(*) as donation_count
+      FROM Donations
+      GROUP BY KID_fordeling
+    )
+    SELECT
+      D.KID,
+      Donors.full_name,
+      Donors.email,
+      IFNULL(DS.donation_sum, 0) as donation_sum,
+      IFNULL(DS.donation_count, 0) as donation_count,
+      ${taxUnitTypeSql}
+    FROM Distributions D
+    INNER JOIN Donors ON D.Donor_ID = Donors.ID
+    LEFT JOIN DonationStats DS ON D.KID = DS.KID_fordeling
+    LEFT JOIN Tax_unit ON D.Tax_unit_ID = Tax_unit.ID
+    ${whereStatement}
+    ${orderByClause}
+    LIMIT ${sqlString.escape(limit)} OFFSET ${sqlString.escape(limit * page)}
+  `;
+
+  const pageFirstRowsQuery = `
+    WITH PageDistributions AS (
+      SELECT
+        D.KID,
+        D.Donor_ID,
+        D.Tax_unit_ID
+      FROM Distributions D
+      INNER JOIN Donors ON D.Donor_ID = Donors.ID
+      ${whereStatement}
+      ${orderByClause}
+      LIMIT ${sqlString.escape(limit)} OFFSET ${sqlString.escape(limit * page)}
+    ),
+    DonationStats AS (
+      SELECT
+        Donations.KID_fordeling,
+        SUM(Donations.sum_confirmed) as donation_sum,
+        COUNT(*) as donation_count
+      FROM Donations
+      INNER JOIN PageDistributions PD ON Donations.KID_fordeling = PD.KID
+      GROUP BY Donations.KID_fordeling
+    )
+    SELECT
+      PD.KID,
+      Donors.full_name,
+      Donors.email,
+      IFNULL(DS.donation_sum, 0) as donation_sum,
+      IFNULL(DS.donation_count, 0) as donation_count,
+      CASE
+        WHEN Tax_unit.ID IS NULL THEN 'none'
+        WHEN LENGTH(Tax_unit.ssn) = 9 THEN 'business'
+        ELSE 'person'
+      END as tax_unit_type
+    FROM PageDistributions PD
+    INNER JOIN Donors ON PD.Donor_ID = Donors.ID
+    LEFT JOIN DonationStats DS ON PD.KID = DS.KID_fordeling
+    LEFT JOIN Tax_unit ON PD.Tax_unit_ID = Tax_unit.ID
+    ${orderByClause.replace("D.KID", "PD.KID")}
+  `;
+
+  const [resultRows, numDistributions] = exportAll
+    ? [(await DAO.query<DistributionExportRow[]>(exportRowsQuery))[0], 0]
+    : isPageFirstSort
+    ? await Promise.all([
+        DAO.query<DistributionListRowDb[]>(pageFirstRowsQuery).then(([rows]) => rows),
+        DAO.query<{ total_rows: number }[]>(countQuery).then(([rows]) => rows[0]?.total_rows || 0),
+      ])
+    : await Promise.all([
+        DAO.query<DistributionListRowDb[]>(fullRowsQuery).then(([rows]) => rows),
+        DAO.query<{ total_rows: number }[]>(countQuery).then(([rows]) => rows[0]?.total_rows || 0),
+      ]);
 
   if (resultRows.length === 0) {
     return {
@@ -175,23 +295,37 @@ export async function getAll(
     };
   }
 
-  const numDistributions = resultRows[0]["total_rows"] || 0;
-  const pages = Math.ceil(numDistributions / limit);
+  const totalDistributions = exportAll ? resultRows.length : numDistributions;
+  const pages = Math.ceil(totalDistributions / limit);
+  const distributionsByKID = exportAll
+    ? new Map<string, Distribution>()
+    : await getDistributionsByKIDs(resultRows.map((row) => row.KID));
 
-  // 4. Map the raw SQL result to the strongly-typed DistributionRow array
-  // The row from the DB is already flat, so we just need to parse numbers
-  const mappedRows: DistributionRow[] = resultRows.map((row) => {
-    const mappedRow: DistributionRow = {
+  const mappedRows = resultRows.map((row) => {
+    if (!exportAll) {
+      const mappedRow: DistributionRow = {
+        KID: row.KID,
+        full_name: row.full_name,
+        email: row.email,
+        donation_sum: Number(row.donation_sum) || 0,
+        donation_count: Number(row.donation_count) || 0,
+        tax_unit_type: row.tax_unit_type,
+        causeAreas: distributionsByKID.get(row.KID)?.causeAreas || [],
+      };
+
+      return mappedRow;
+    }
+
+    const mappedRow: DistributionExportRow = {
       KID: row.KID,
       full_name: row.full_name,
       email: row.email,
-      donation_sum: row.donation_sum,
-      donation_count: row.donation_count,
+      donation_sum: Number(row.donation_sum) || 0,
+      donation_count: Number(row.donation_count) || 0,
+      tax_unit_type: row.tax_unit_type,
     };
 
     for (const org of activeOrgs) {
-      // The key is the org abbreviation (e.g., "EFF")
-      // The value is the share, parsed from a decimal string to a number
       mappedRow[org.abbriv] = parseFloat(row[org.abbriv] || "0");
     }
 
@@ -201,7 +335,7 @@ export async function getAll(
   return {
     rows: mappedRows,
     statistics: {
-      numDistributions,
+      numDistributions: totalDistributions,
     },
     pages,
   };
@@ -519,6 +653,40 @@ async function getSplitByKID(KID: string): Promise<Distribution> {
   if (result.length == 0) throw new Error("NOT FOUND | No distribution with the KID " + KID);
 
   return mapDbDistributionToDistribution(result);
+}
+
+async function getDistributionsByKIDs(KIDs: string[]): Promise<Map<string, Distribution>> {
+  if (KIDs.length === 0) {
+    return new Map();
+  }
+
+  const [result] = await DAO.query<DistributionDbResult>(
+    `
+        SELECT *,
+          CAO.Percentage_share AS Organization_percentage_share,
+          CA.Percentage_share AS Cause_area_percentage_share,
+          C.name AS Cause_area_name,
+          O.full_name AS Organization_name,
+          O.widget_display_name AS Organization_widget_display_name
+
+        FROM 
+          Distributions AS D
+          LEFT JOIN Distribution_cause_areas AS CA ON CA.Distribution_KID = D.KID
+          LEFT JOIN Distribution_cause_area_organizations AS CAO ON CAO.Distribution_cause_area_ID = CA.ID
+          INNER JOIN Cause_areas AS C ON C.ID = CA.Cause_area_ID
+          INNER JOIN Organizations AS O ON O.ID = CAO.Organization_ID
+        
+        WHERE 
+            D.KID IN (${KIDs.map((kid) => sqlString.escape(kid)).join(", ")})
+        ORDER BY D.KID`,
+  );
+
+  return new Map(
+    mapDbDistributionsToDistributions(result).map((distribution) => [
+      distribution.kid,
+      distribution,
+    ]),
+  );
 }
 
 /**
@@ -934,6 +1102,7 @@ export const distributions = {
   KIDexists,
   getKIDbySplit,
   getSplitByKID,
+  getDistributionsByKIDs,
   getStandardDistributionByCauseAreaID,
   getHistoricPaypalSubscriptionKIDS,
   getAll,

--- a/src/custom_modules/DAO_modules/donations.ts
+++ b/src/custom_modules/DAO_modules/donations.ts
@@ -1,6 +1,6 @@
 import { distributions } from "./distributions";
 import { DAO } from "../DAO";
-import { Donation } from "../../schemas/types";
+import { DistributionCauseArea, Donation } from "../../schemas/types";
 
 import sqlString from "sqlstring";
 import { DateTime } from "luxon";
@@ -65,6 +65,7 @@ async function getAll(
     organizationIDs?: Array<number>;
   } = null,
   locale: RequestLocale,
+  exportAll = false,
 ): Promise<{
   rows: Array<{
     id: number;
@@ -74,6 +75,8 @@ async function getAll(
     transactionCost: number;
     kid: string;
     timestamp: Date;
+    taxUnitType: string | null;
+    causeAreas?: DistributionCauseArea[];
   }>;
   statistics: {
     numDonations: number;
@@ -82,187 +85,276 @@ async function getAll(
   };
   pages: number;
 }> {
-  if (sort) {
-    const sortColumn = jsDBmapping.find((map) => map[0] === sort.id)[1];
-
-    const taxUnitTypeFildDefinition = getTaxUnitTypeFieldDefinition(locale);
-
-    let where = [];
-    if (filter) {
-      if (filter.sum) {
-        if (filter.sum.from) where.push(`sum_confirmed >= ${sqlString.escape(filter.sum.from)} `);
-        if (filter.sum.to) where.push(`sum_confirmed <= ${sqlString.escape(filter.sum.to)} `);
-      }
-
-      if (filter.date) {
-        if (filter.date.from)
-          where.push(`timestamp_confirmed >= ${sqlString.escape(filter.date.from)} `);
-        if (filter.date.to)
-          where.push(`timestamp_confirmed <= ${sqlString.escape(filter.date.to)} `);
-      }
-
-      if (filter.KID)
-        where.push(` CAST(KID_fordeling as CHAR) LIKE ${sqlString.escape(`%${filter.KID}%`)} `);
-      if (filter.paymentMethodIDs) {
-        if (filter.paymentMethodIDs.length == 0) {
-          return {
-            rows: [],
-            statistics: {
-              numDonations: 0,
-              sumDonations: 0,
-              avgDonation: 0,
-            },
-            pages: 0,
-          };
-        }
-        where.push(
-          ` Payment_ID IN (${filter.paymentMethodIDs
-            .map((ID) => sqlString.escape(ID))
-            .join(",")}) `,
-        );
-      }
-
-      if (filter.donor)
-        where.push(
-          ` (Donors.full_name LIKE ${sqlString.escape(
-            `%${filter.donor}%`,
-          )} OR Donors.email LIKE ${sqlString.escape(`%${filter.donor}%`)}) `,
-        );
-
-      if (filter.id) where.push(` Donations.ID LIKE ${sqlString.escape(`${filter.id}%`)} `);
-
-      if (filter.fundraiserId) {
-        // Ensure the join happens below if filter.fundraiserId is present
-        // Using FT as alias for Fundraiser_transactions table
-        where.push(` FT.Fundraiser_ID = ${sqlString.escape(filter.fundraiserId)} `);
-      }
-
-      if (filter.taxUnitTypes) {
-        if (filter.taxUnitTypes.length == 0) {
-          return {
-            rows: [],
-            statistics: {
-              numDonations: 0,
-              sumDonations: 0,
-              avgDonation: 0,
-            },
-            pages: 0,
-          };
-        }
-        const types = filter.taxUnitTypes
-          .filter((type) => type)
-          .map((type) => sqlString.escape(type));
-        const hasTypes = types.length > 0;
-        const includeUnknown = filter.taxUnitTypes.includes(null);
-        const or = hasTypes && includeUnknown ? " OR " : "";
-
-        const typesQuery = hasTypes ? `${taxUnitTypeFildDefinition} IN (${types.join(",")})` : "";
-        const unknownQuery = includeUnknown ? `${or} Tax_unit.ID IS NULL` : "";
-
-        where.push(
-          ` (
-            ${typesQuery}
-            ${unknownQuery}
-          ) `,
-        );
-      }
-
-      if (filter.organizationIDs) {
-        if (filter.organizationIDs.length == 0) {
-          return {
-            rows: [],
-            statistics: {
-              numDonations: 0,
-              sumDonations: 0,
-              avgDonation: 0,
-            },
-            pages: 0,
-          };
-        }
-        where.push(
-          ` Distribution_cause_area_organizations.Organization_ID IN (${filter.organizationIDs
-            .map(sqlString.escape)
-            .join(",")}) `,
-        );
-      }
-    }
-
-    // Only apply this join when filtering by organizationIDs.
-    const organizationJoin = filter?.organizationIDs
-      ? `
-        LEFT JOIN Distribution_cause_areas
-          ON Distributions.KID = Distribution_cause_areas.Distribution_KID
-        LEFT JOIN Distribution_cause_area_organizations
-          ON Distribution_cause_areas.ID = Distribution_cause_area_organizations.Distribution_cause_area_ID`
-      : "";
-
-    const fundraiserJoin = filter.fundraiserId
-      ? `
-        LEFT JOIN Fundraiser_transactions FT
-          ON Distributions.Fundraiser_transaction_ID = FT.ID`
-      : "";
-
-    const query = `
-        WITH filtered_donations AS (
-          SELECT DISTINCT
-            Donations.ID,
-            Donors.full_name,
-            Payment.abbriv as payment_name,
-            Donations.sum_confirmed,
-            Donations.transaction_cost,
-            Donations.KID_fordeling,
-            Donations.timestamp_confirmed,
-            ${taxUnitTypeFildDefinition} as tax_unit_type
-          FROM Donations
-          INNER JOIN Donors
-            ON Donations.Donor_ID = Donors.ID
-          INNER JOIN Payment
-            ON Donations.Payment_ID = Payment.ID  
-          INNER JOIN Distributions
-            ON Donations.KID_fordeling = Distributions.KID
-          LEFT JOIN Tax_unit
-            ON Distributions.Tax_unit_ID = Tax_unit.ID
-          ${organizationJoin}
-          ${fundraiserJoin}
-          WHERE ${where.length !== 0 ? where.join(" AND ") : "1"}
-        ),
-        statistics AS (
-          SELECT 
-            COUNT(*) as full_count,
-            SUM(sum_confirmed) as full_sum,
-            AVG(sum_confirmed) as full_avg
-          FROM filtered_donations
-        )
-        SELECT 
-          d.*,
-          s.full_count,
-          s.full_sum,
-          s.full_avg
-        FROM filtered_donations d
-        CROSS JOIN statistics s
-        ORDER BY ${sortColumn} ${sort.desc ? "DESC" : ""} 
-        LIMIT ? OFFSET ?`;
-
-    const [donations] = await DAO.query(query, [limit, page * limit]);
-
-    const numDonations = donations.length > 0 ? donations[0]["full_count"] : 0;
-    const sumDonations = donations.length > 0 ? donations[0]["full_sum"] : 0;
-    const avgDonation = donations.length > 0 ? donations[0]["full_avg"] : 0;
-
-    const pages = Math.ceil(numDonations / limit);
-
-    return {
-      rows: mapToJS(donations),
-      statistics: {
-        numDonations,
-        sumDonations,
-        avgDonation,
-      },
-      pages,
-    };
-  } else {
+  if (!sort) {
     throw new Error("No sort provided");
   }
+
+  const sortColumn = jsDBmapping.find((map) => map[0] === sort.id)[1];
+  const taxUnitTypeFildDefinition = getTaxUnitTypeFieldDefinition(locale);
+  const donationConditions = [];
+  const joinedConditions = [];
+  const hasOrganizationFilter = Boolean(filter?.organizationIDs?.length);
+  const hasDonorFilter = Boolean(filter?.donor);
+  const hasFundraiserFilter = Boolean(filter?.fundraiserId);
+  const hasTaxUnitTypeFilter = Boolean(filter?.taxUnitTypes);
+
+  if (filter) {
+    if (filter.sum) {
+      if (filter.sum.from != null)
+        donationConditions.push(`Donations.sum_confirmed >= ${sqlString.escape(filter.sum.from)} `);
+      if (filter.sum.to != null)
+        donationConditions.push(`Donations.sum_confirmed <= ${sqlString.escape(filter.sum.to)} `);
+    }
+
+    if (filter.date) {
+      if (filter.date.from != null)
+        donationConditions.push(
+          `Donations.timestamp_confirmed >= ${sqlString.escape(filter.date.from)} `,
+        );
+      if (filter.date.to != null)
+        donationConditions.push(
+          `Donations.timestamp_confirmed <= ${sqlString.escape(filter.date.to)} `,
+        );
+    }
+
+    if (filter.KID)
+      donationConditions.push(
+        `CAST(Donations.KID_fordeling as CHAR) LIKE ${sqlString.escape(`%${filter.KID}%`)} `,
+      );
+
+    if (filter.paymentMethodIDs) {
+      if (filter.paymentMethodIDs.length == 0) {
+        return {
+          rows: [],
+          statistics: {
+            numDonations: 0,
+            sumDonations: 0,
+            avgDonation: 0,
+          },
+          pages: 0,
+        };
+      }
+      donationConditions.push(
+        `Donations.Payment_ID IN (${filter.paymentMethodIDs
+          .map((ID) => sqlString.escape(ID))
+          .join(",")}) `,
+      );
+    }
+
+    if (filter.donor)
+      joinedConditions.push(
+        `(Donors.full_name LIKE ${sqlString.escape(
+          `%${filter.donor}%`,
+        )} OR Donors.email LIKE ${sqlString.escape(`%${filter.donor}%`)}) `,
+      );
+
+    if (filter.id)
+      donationConditions.push(`Donations.ID LIKE ${sqlString.escape(`${filter.id}%`)} `);
+
+    if (filter.fundraiserId) {
+      joinedConditions.push(`FT.Fundraiser_ID = ${sqlString.escape(filter.fundraiserId)} `);
+    }
+
+    if (filter.taxUnitTypes) {
+      if (filter.taxUnitTypes.length == 0) {
+        return {
+          rows: [],
+          statistics: {
+            numDonations: 0,
+            sumDonations: 0,
+            avgDonation: 0,
+          },
+          pages: 0,
+        };
+      }
+
+      const types = filter.taxUnitTypes
+        .filter((type) => type)
+        .map((type) => sqlString.escape(type));
+      const hasTypes = types.length > 0;
+      const includeUnknown = filter.taxUnitTypes.includes(null);
+      const or = hasTypes && includeUnknown ? " OR " : "";
+
+      const typesQuery = hasTypes ? `${taxUnitTypeFildDefinition} IN (${types.join(",")})` : "";
+      const unknownQuery = includeUnknown ? `${or} Tax_unit.ID IS NULL` : "";
+
+      joinedConditions.push(
+        `(
+          ${typesQuery}
+          ${unknownQuery}
+        ) `,
+      );
+    }
+
+    if (filter.organizationIDs) {
+      if (filter.organizationIDs.length == 0) {
+        return {
+          rows: [],
+          statistics: {
+            numDonations: 0,
+            sumDonations: 0,
+            avgDonation: 0,
+          },
+          pages: 0,
+        };
+      }
+      joinedConditions.push(
+        `Distribution_cause_area_organizations.Organization_ID IN (${filter.organizationIDs
+          .map(sqlString.escape)
+          .join(",")}) `,
+      );
+    }
+  }
+
+  const organizationJoin = hasOrganizationFilter
+    ? `
+      LEFT JOIN Distribution_cause_areas
+        ON Distributions.KID = Distribution_cause_areas.Distribution_KID
+      LEFT JOIN Distribution_cause_area_organizations
+        ON Distribution_cause_areas.ID = Distribution_cause_area_organizations.Distribution_cause_area_ID`
+    : "";
+
+  const fundraiserJoin = hasFundraiserFilter
+    ? `
+      LEFT JOIN Fundraiser_transactions FT
+        ON Distributions.Fundraiser_transaction_ID = FT.ID`
+    : "";
+
+  const rowWhere = [...donationConditions, ...joinedConditions];
+  const statsWhere = hasOrganizationFilter
+    ? [
+        ...donationConditions,
+        ...joinedConditions.filter(
+          (condition) =>
+            !condition.includes("Distribution_cause_area_organizations.Organization_ID"),
+        ),
+      ]
+    : [...donationConditions, ...joinedConditions];
+
+  const rowQuery = `
+      SELECT ${hasOrganizationFilter ? "DISTINCT" : ""}
+        Donations.ID,
+        Donors.full_name,
+        Payment.abbriv as payment_name,
+        Donations.sum_confirmed,
+        Donations.transaction_cost,
+        Donations.KID_fordeling,
+        Donations.timestamp_confirmed,
+        ${taxUnitTypeFildDefinition} as tax_unit_type
+      FROM Donations
+      INNER JOIN Donors
+        ON Donations.Donor_ID = Donors.ID
+      INNER JOIN Payment
+        ON Donations.Payment_ID = Payment.ID
+      INNER JOIN Distributions
+        ON Donations.KID_fordeling = Distributions.KID
+      LEFT JOIN Tax_unit
+        ON Distributions.Tax_unit_ID = Tax_unit.ID
+      ${organizationJoin}
+      ${fundraiserJoin}
+      WHERE ${rowWhere.length !== 0 ? rowWhere.join(" AND ") : "1"}
+      ORDER BY ${sortColumn} ${sort.desc ? "DESC" : ""}
+      LIMIT ? OFFSET ?`;
+
+  const statsDonorJoin = hasDonorFilter
+    ? `
+      INNER JOIN Donors
+        ON Donations.Donor_ID = Donors.ID`
+    : "";
+  const statsDistributionsJoin =
+    hasTaxUnitTypeFilter || hasFundraiserFilter
+      ? `
+      INNER JOIN Distributions
+        ON Donations.KID_fordeling = Distributions.KID`
+      : "";
+  const statsTaxUnitJoin = hasTaxUnitTypeFilter
+    ? `
+      LEFT JOIN Tax_unit
+        ON Distributions.Tax_unit_ID = Tax_unit.ID`
+    : "";
+  const statsFundraiserJoin = hasFundraiserFilter
+    ? `
+      LEFT JOIN Fundraiser_transactions FT
+        ON Distributions.Fundraiser_transaction_ID = FT.ID`
+    : "";
+
+  const statsQuery = hasOrganizationFilter
+    ? `
+      WITH eligible_kids AS (
+        SELECT DISTINCT
+          Distribution_cause_areas.Distribution_KID
+        FROM Distribution_cause_areas
+        INNER JOIN Distribution_cause_area_organizations
+          ON Distribution_cause_areas.ID = Distribution_cause_area_organizations.Distribution_cause_area_ID
+        WHERE Distribution_cause_area_organizations.Organization_ID IN (${filter.organizationIDs
+          .map(sqlString.escape)
+          .join(",")})
+      )
+      SELECT
+        COUNT(*) as full_count,
+        SUM(Donations.sum_confirmed) as full_sum,
+        AVG(Donations.sum_confirmed) as full_avg
+      FROM eligible_kids
+      STRAIGHT_JOIN Donations
+        ON Donations.KID_fordeling = eligible_kids.Distribution_KID
+      ${statsDonorJoin}
+      ${statsDistributionsJoin}
+      ${statsTaxUnitJoin}
+      ${statsFundraiserJoin}
+      WHERE ${statsWhere.length !== 0 ? statsWhere.join(" AND ") : "1"}`
+    : `
+      SELECT
+        COUNT(*) as full_count,
+        SUM(Donations.sum_confirmed) as full_sum,
+        AVG(Donations.sum_confirmed) as full_avg
+      FROM Donations
+      ${statsDonorJoin}
+      ${statsDistributionsJoin}
+      ${statsTaxUnitJoin}
+      ${statsFundraiserJoin}
+      WHERE ${statsWhere.length !== 0 ? statsWhere.join(" AND ") : "1"}`;
+
+  const [[donations], [statisticsRows]] = await Promise.all([
+    DAO.query(rowQuery, [limit, page * limit]),
+    DAO.query<{ full_count: number; full_sum: number; full_avg: number }[]>(statsQuery),
+  ]);
+
+  const numDonations = statisticsRows.length > 0 ? statisticsRows[0].full_count : 0;
+  const sumDonations = statisticsRows.length > 0 ? statisticsRows[0].full_sum : 0;
+  const avgDonation = statisticsRows.length > 0 ? statisticsRows[0].full_avg : 0;
+  const pages = Math.ceil(numDonations / limit);
+  const mappedDonations = mapToJS(donations) as Array<{
+    id: number;
+    donor: string;
+    paymentMethod: string;
+    sum: number;
+    transactionCost: number;
+    kid: string;
+    timestamp: Date;
+    taxUnitType: string | null;
+  }>;
+  const distributionDetailsByKID = exportAll
+    ? new Map<string, any>()
+    : await distributions.getDistributionsByKIDs([
+        ...new Set(mappedDonations.map((donation) => donation.kid)),
+      ]);
+
+  return {
+    rows: mappedDonations.map((donation) =>
+      exportAll
+        ? donation
+        : {
+            ...donation,
+            causeAreas: distributionDetailsByKID.get(donation.kid)?.causeAreas || [],
+          },
+    ),
+    statistics: {
+      numDonations,
+      sumDonations,
+      avgDonation,
+    },
+    pages,
+  };
 }
 
 async function getTransactionCostsReport() {

--- a/src/custom_modules/DAO_modules/donors.ts
+++ b/src/custom_modules/DAO_modules/donors.ts
@@ -112,6 +112,8 @@ async function getAll(
   statistics: DonorStatistics;
   pages: number;
 }> {
+  const startedAt = Date.now();
+
   if (!sort) {
     throw new Error("No sort provided for getAllDonors");
   }
@@ -123,7 +125,6 @@ async function getAll(
   const sortColumn = sortColumnEntry[1];
 
   let whereClauses: string[] = [];
-  let joins: string[] = [];
   let donationDateFilterSqlForCTE = ""; // For filtering donations within the CTE
   let donationDateFilterSqlForSubqueries = ""; // For filtering donations within subqueries
 
@@ -153,18 +154,17 @@ async function getAll(
   }
 
   const donorAggregatesCTE = `
-    DonorAggregates AS (
+    DonationAggregates AS (
       SELECT
-        Donors.ID as donor_id_agg,
+        Dons.Donor_ID as donor_id_agg,
         MAX(Dons.timestamp_confirmed) as last_donation_date,
-        COUNT(DISTINCT Dons.ID) as donations_count,
+        COUNT(Dons.ID) as donations_count,
         COALESCE(SUM(Dons.sum_confirmed), 0) as donations_sum
-      FROM Donors
-      LEFT JOIN Donations Dons ON Donors.ID = Dons.Donor_ID ${donationDateFilterSqlForCTE} -- Applied here
-      GROUP BY Donors.ID
+      FROM Donations Dons
+      WHERE 1 ${donationDateFilterSqlForCTE}
+      GROUP BY Dons.Donor_ID
     )
   `;
-  joins.push(`LEFT JOIN DonorAggregates Aggregates ON Donors.ID = Aggregates.donor_id_agg`);
 
   if (filter) {
     if (filter.donorId !== null) {
@@ -224,12 +224,15 @@ async function getAll(
     }
 
     if (filter.donationsCount) {
-      if (filter.donationsCount.from) {
+      if (
+        filter.donationsCount.from !== null &&
+        typeof filter.donationsCount.from !== "undefined"
+      ) {
         whereClauses.push(
           `Aggregates.donations_count >= ${sqlString.escape(filter.donationsCount.from)}`,
         );
       }
-      if (filter.donationsCount.to) {
+      if (filter.donationsCount.to !== null && typeof filter.donationsCount.to !== "undefined") {
         whereClauses.push(
           `Aggregates.donations_count <= ${sqlString.escape(filter.donationsCount.to)}`,
         );
@@ -237,12 +240,12 @@ async function getAll(
     }
 
     if (filter.donationsSum) {
-      if (filter.donationsSum.from) {
+      if (filter.donationsSum.from !== null && typeof filter.donationsSum.from !== "undefined") {
         whereClauses.push(
           `Aggregates.donations_sum >= ${sqlString.escape(filter.donationsSum.from)}`,
         );
       }
-      if (filter.donationsSum.to) {
+      if (filter.donationsSum.to !== null && typeof filter.donationsSum.to !== "undefined") {
         whereClauses.push(
           `Aggregates.donations_sum <= ${sqlString.escape(filter.donationsSum.to)}`,
         );
@@ -259,9 +262,15 @@ async function getAll(
           pages: 0,
         };
       }
-      joins.push(`LEFT JOIN Referral_records RR ON Donors.ID = RR.DonorID`);
       whereClauses.push(
-        `RR.ReferralID IN (${filter.referralTypeIDs.map((id) => sqlString.escape(id)).join(",")})`,
+        `EXISTS (
+          SELECT 1
+          FROM Referral_records RR
+          WHERE RR.DonorID = Donors.ID
+            AND RR.ReferralID IN (${filter.referralTypeIDs
+              .map((id) => sqlString.escape(id))
+              .join(",")})
+        )`,
       );
     }
 
@@ -334,35 +343,32 @@ async function getAll(
 
   const whereStatement =
     whereClauses.length > 0 ? `WHERE ${whereClauses.join(" AND ")}` : "WHERE 1";
-  const joinStatement = joins.join(" \n ");
-
   const query = `
     WITH ${donorAggregatesCTE},
     FilteredDonors AS (
-      SELECT DISTINCT
+      SELECT
         Donors.ID,
         Donors.full_name,
         Donors.email,
         Donors.date_registered,
         Donors.newsletter,
         Aggregates.last_donation_date,
-        Aggregates.donations_count,
-        Aggregates.donations_sum
+        COALESCE(Aggregates.donations_count, 0) as donations_count,
+        COALESCE(Aggregates.donations_sum, 0) as donations_sum
       FROM Donors
-      ${joinStatement}
+      LEFT JOIN DonationAggregates Aggregates ON Donors.ID = Aggregates.donor_id_agg
       ${whereStatement}
     ),
     TotalCount AS (
       SELECT COUNT(*) as total_donors_count FROM FilteredDonors
-      
     ),
     TotalSum AS (
-      SELECT 
-        SUM(donations_sum) as total_donations_sum,
-        SUM(donations_count) as total_donations_count
+      SELECT
+        COALESCE(SUM(donations_sum), 0) as total_donations_sum,
+        COALESCE(SUM(donations_count), 0) as total_donations_count
       FROM FilteredDonors
     )
-    SELECT 
+    SELECT
       FD.*,
       TC.total_donors_count,
       TS.total_donations_sum,
@@ -374,13 +380,16 @@ async function getAll(
     LIMIT ${sqlString.escape(limit)} OFFSET ${sqlString.escape(page * limit)};
   `;
 
+  const queryStartedAt = Date.now();
   const [resultRows]: [any[], any] = await DAO.query(query, []);
+  const queryMs = Date.now() - queryStartedAt;
 
   const totalDonors = resultRows.length > 0 ? resultRows[0]["total_donors_count"] : 0;
   const totalDonationSum = resultRows.length > 0 ? resultRows[0]["total_donations_sum"] : 0;
   const totalDonationCount = resultRows.length > 0 ? resultRows[0]["total_donations_count"] : 0;
   const pages = Math.ceil(totalDonors / limit);
 
+  const mapStartedAt = Date.now();
   const mappedRows: DonorRow[] = resultRows.map((row) => ({
     id: row.ID,
     name: row.full_name,
@@ -391,6 +400,15 @@ async function getAll(
     donationsSum: parseFloat(row.donations_sum) || 0.0,
     newsletter: row.newsletter === 1,
   }));
+  const mapMs = Date.now() - mapStartedAt;
+
+  console.log(
+    `[DAO.donors.getAll] totalMs=${Date.now() - startedAt} queryMs=${queryMs} mapMs=${mapMs} rows=${
+      mappedRows.length
+    } totalDonors=${totalDonors} sort=${sort.id}:${
+      sort.desc ? "desc" : "asc"
+    } page=${page} limit=${limit}`,
+  );
 
   return {
     rows: mappedRows,

--- a/src/routes/distributions.ts
+++ b/src/routes/distributions.ts
@@ -55,6 +55,7 @@ router.post("/search", authMiddleware.isAdmin, async (req, res, next) => {
         Number.MAX_SAFE_INTEGER,
         req.body.sort,
         req.body.filter,
+        true,
       );
 
       return exportCsv(res, results.rows, `distributions-${new Date().toISOString()}.csv`);

--- a/src/routes/donations.ts
+++ b/src/routes/donations.ts
@@ -534,6 +534,7 @@ router.post(
           Number.MAX_SAFE_INTEGER,
           req.body.filter,
           req.locale,
+          true,
         );
 
         return exportCsv(res, results.rows, `donations-${new Date().toISOString()}.csv`);

--- a/src/routes/donors.ts
+++ b/src/routes/donors.ts
@@ -151,6 +151,7 @@ router.post("/auth0/register", async (req, res, next) => {
 });
 
 router.post("/list/", authMiddleware.isAdmin, async (req, res, next) => {
+  const startedAt = Date.now();
   try {
     if (req.body.export === true) {
       const results = await DAO.donors.getAll(
@@ -161,6 +162,11 @@ router.post("/list/", authMiddleware.isAdmin, async (req, res, next) => {
         req.locale,
       );
 
+      console.log(
+        `[routes/donors/list] export handlerMs=${Date.now() - startedAt} rows=${
+          results.rows.length
+        }`,
+      );
       return exportCsv(res, results.rows, `donors-${new Date().toISOString()}.csv`);
     }
 
@@ -178,6 +184,13 @@ router.post("/list/", authMiddleware.isAdmin, async (req, res, next) => {
       req.body.filter,
       req.locale,
     );
+
+    console.log(
+      `[routes/donors/list] handlerMs=${Date.now() - startedAt} rows=${results.rows.length} pages=${
+        results.pages
+      }`,
+    );
+
     return res.json({
       status: 200,
       content: {


### PR DESCRIPTION
## Summary
- optimize donations, distributions, and donors list queries for the admin UI
- keep CSV export behavior intact while using cheaper paginated paths for interactive list requests
- enrich non-export list rows with nested distribution cause areas for distributions and donations

## Details
- donations: split rows and statistics, improve org-filter stats path, and attach page-scoped cause areas only for non-export responses
- distributions: paginate before expensive enrichment for list requests, keep full export path, and return structured cause areas plus tax unit type in the JSON API
- donors: switch to donations-first donor aggregation, remove unnecessary DISTINCT work, use EXISTS for referral filtering, and fix zero-bound donor filters

## Verification
- npx tsc --noEmit
- npx mocha --no-config --require ts-node/register --require dotenv/config src/__test__/DAO/distributions.spec.ts
- benchmarked live SQL plans and verified improved endpoint timings locally
