### PR TITLE
Trim donor emails so lookups stop minting duplicate donors

### DIFF
--- a/src/__test__/donorEmail.spec.ts
+++ b/src/__test__/donorEmail.spec.ts
@@ -1,0 +1,94 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import { DAO } from "../custom_modules/DAO";
+import { normalizeDonorEmail } from "../custom_modules/donorEmail";
+
+describe("normalizeDonorEmail", function () {
+  it("strips surrounding whitespace", function () {
+    expect(normalizeDonorEmail("jack@overlookhotel.com ")).to.equal("jack@overlookhotel.com");
+    expect(normalizeDonorEmail(" jack@overlookhotel.com")).to.equal("jack@overlookhotel.com");
+    expect(normalizeDonorEmail("\tjack@overlookhotel.com\n")).to.equal("jack@overlookhotel.com");
+  });
+
+  it("leaves a clean address untouched", function () {
+    expect(normalizeDonorEmail("jack@overlookhotel.com")).to.equal("jack@overlookhotel.com");
+  });
+
+  it("passes through null and undefined", function () {
+    expect(normalizeDonorEmail(null)).to.equal(null);
+    expect(normalizeDonorEmail(undefined)).to.equal(undefined);
+  });
+
+  /**
+   * The cases below are the point of the helper being this conservative. Each of
+   * these transformations merges mailboxes that can belong to different people,
+   * and a donor id is all it takes to read another donor's donations and tax
+   * units, so none of them may creep in later.
+   */
+  it("does not change case", function () {
+    expect(normalizeDonorEmail("Jack@OverlookHotel.com")).to.equal("Jack@OverlookHotel.com");
+  });
+
+  it("does not strip dots from the local part", function () {
+    expect(normalizeDonorEmail("j.torrance@overlookhotel.com")).to.equal(
+      "j.torrance@overlookhotel.com",
+    );
+  });
+
+  it("does not strip subaddress tags", function () {
+    expect(normalizeDonorEmail("jack+effekt@overlookhotel.com")).to.equal(
+      "jack+effekt@overlookhotel.com",
+    );
+  });
+
+  it("does not touch whitespace inside a quoted local part", function () {
+    expect(normalizeDonorEmail('"jack torrance"@overlookhotel.com')).to.equal(
+      '"jack torrance"@overlookhotel.com',
+    );
+  });
+});
+
+describe("donors DAO email normalization", function () {
+  /**
+   * A scoped sandbox rather than the default one. Several specs in this suite
+   * install stubs from module scope or from a before hook and rely on them for
+   * their whole run, and a bare sinon.restore() here would tear those down.
+   */
+  const sandbox = sinon.createSandbox();
+  let executeStub: sinon.SinonStub;
+  let queryStub: sinon.SinonStub;
+
+  beforeEach(function () {
+    executeStub = sandbox.stub(DAO, "execute");
+    queryStub = sandbox.stub(DAO, "query");
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("looks up donors by the trimmed address", async function () {
+    executeStub.resolves([[{ ID: 237 }]]);
+
+    const id = await DAO.donors.getIDbyEmail("jack@overlookhotel.com ");
+
+    expect(id).to.equal(237);
+    expect(executeStub.firstCall.args[1]).to.deep.equal(["jack@overlookhotel.com"]);
+  });
+
+  it("stores new donors with the trimmed address", async function () {
+    queryStub.resolves([{ insertId: 237 }]);
+
+    await DAO.donors.add({ email: " jack@overlookhotel.com ", full_name: "Jack Torrance" });
+
+    expect(queryStub.firstCall.args[1][0]).to.equal("jack@overlookhotel.com");
+  });
+
+  it("stores updated donors with the trimmed address", async function () {
+    queryStub.resolves([{ affectedRows: 1 }]);
+
+    await DAO.donors.update(237, "Jack Torrance", "jack@overlookhotel.com ", true, false);
+
+    expect(queryStub.firstCall.args[1][1]).to.equal("jack@overlookhotel.com");
+  });
+});

--- a/src/custom_modules/DAO_modules/donors.ts
+++ b/src/custom_modules/DAO_modules/donors.ts
@@ -3,6 +3,7 @@ import { Donor } from "../../schemas/types";
 import { DAO } from "../DAO";
 import * as sqlString from "sqlstring";
 import { RequestLocale } from "../../middleware/locale";
+import { normalizeDonorEmail } from "../donorEmail";
 
 //region Get
 
@@ -409,7 +410,9 @@ async function getAll(
  * @returns {Number} An ID
  */
 async function getIDbyEmail(email): Promise<number | null> {
-  var [result] = await DAO.execute(`SELECT ID FROM Donors where email = ?`, [email]);
+  var [result] = await DAO.execute(`SELECT ID FROM Donors where email = ?`, [
+    normalizeDonorEmail(email),
+  ]);
 
   if (result.length > 0) return result[0].ID;
   else return null;
@@ -676,7 +679,7 @@ async function add(
         full_name, 
         newsletter
     ) VALUES (?,?,?)`,
-    [data.email, data.full_name || null, data.newsletter || false],
+    [normalizeDonorEmail(data.email), data.full_name || null, data.newsletter || false],
   );
 
   return res[0].insertId;
@@ -720,7 +723,7 @@ async function update(donorID, name, email, newsletter, trash?: boolean) {
 
   let [res] = await DAO.query(
     `UPDATE Donors SET full_name = ?, email = ?, newsletter = ?, trash = ? where ID = ?`,
-    [name, email, newsletter, isTrash, donorID],
+    [name, normalizeDonorEmail(email), newsletter, isTrash, donorID],
   );
 
   if (res.affectedRows === 1) {

--- a/src/custom_modules/donorEmail.ts
+++ b/src/custom_modules/donorEmail.ts
@@ -1,0 +1,36 @@
+/**
+ * A donor's email is our de-facto identity key - the `email_UNIQUE` index on
+ * Donors.email is what stops us from creating two donor rows for the same
+ * person, and every create-or-get path keys off an exact match against it.
+ *
+ * That index used to normalize whitespace for us. The column was declared with
+ * a PAD SPACE collation (utf8mb4_unicode_ci), under which "a@b.no " and
+ * "a@b.no" compare equal, so a stray trailing space was harmless. Production
+ * now reports utf8mb4_0900_ai_ci, and every MySQL 8 `_0900_` collation is
+ * NO PAD - the two values are distinct. A lookup by the clean address misses
+ * the stored row, and we mint a duplicate donor instead. Since the donor id is
+ * baked into the Auth0 token claim on first login, the donor then signs in to
+ * a brand new, empty donor and sees none of their donations.
+ *
+ * Trimming is safe: RFC 5322 treats whitespace surrounding an address as
+ * folding whitespace that is not part of the addr-spec, so no two deliverable
+ * mailboxes can differ only by leading or trailing whitespace. Interior spaces
+ * in a quoted local part - `"a b"@example.com` - sit inside the quotes and are
+ * left untouched.
+ *
+ * Deliberately NOT done here. Each of these merges genuinely distinct
+ * mailboxes, which would hand one donor access to another donor's donation
+ * history and tax units:
+ *   - stripping dots in the local part (a Gmail convention, not a standard)
+ *   - stripping +tags (subaddressing is not universally implemented)
+ *   - unicode folding or homoglyph mapping
+ *   - domain aliasing (googlemail.com -> gmail.com)
+ *
+ * Case is left alone too. The column collation is case-insensitive, so
+ * comparisons already ignore case, and lowercasing on write would discard the
+ * address as the donor typed it - which is the address we send receipts and
+ * tax reports to. RFC 5321 section 2.4 reserves local-part case sensitivity to
+ * the destination host, so we do not get to decide it is irrelevant.
+ */
+export const normalizeDonorEmail = (email: string | null | undefined) =>
+  typeof email === "string" ? email.trim() : email;

--- a/src/routes/donors.ts
+++ b/src/routes/donors.ts
@@ -129,7 +129,7 @@ router.post("/", authMiddleware.isAdmin, urlEncodeParser, async (req, res, next)
 router.post("/auth0/register", async (req, res, next) => {
   try {
     if (!req.body.email) {
-      res.status(400).json({
+      return res.status(400).json({
         status: 400,
         content: "email is missing in request body",
       });


### PR DESCRIPTION
## Why

`Donors.email` is our de-facto identity key. The `email_UNIQUE` index used to normalize trailing whitespace for us: the column was declared `utf8mb4_unicode_ci`, a **PAD SPACE** collation, under which `"a@b.no "` and `"a@b.no"` compare equal, so a stray trailing space was harmless.

Production now reports `utf8mb4_0900_ai_ci`. Every MySQL 8 `_0900_` collation is **NO PAD**, so those are two distinct values. A create-or-get keyed on the clean address misses the stored row and inserts a duplicate donor instead.

That is the full explanation for the report of a donor logging in to Min side successfully and seeing none of their donations. The Auth0 action calls `POST /donors/auth0/register` on first login, that endpoint minted the duplicate, and the new donor id was then baked into the token claim — so the donor signs in to a brand new, empty donor row.

Note that all five rows still carrying a trailing space were registered in December 2021. They were harmless for three years and only became invisible when the collation changed.

## What this changes

Normalization happens in the donors DAO — `getIDbyEmail`, `add` and `update` — because that is the choke point all six-plus call sites go through, including future ones.

It trims, and only trims. Surrounding whitespace is folding whitespace around the addr-spec per RFC 5322, so it can never be part of a deliverable mailbox — which is what makes trimming unable to merge two different people. Interior spaces in a quoted local part (`"a b"@example.com`) are untouched.

Deliberately **not** done, each with a test pinning it down, because each merges mailboxes that can belong to different people — and a donor id is all it takes to read another donor's donations and tax units:

- stripping dots in the local part (a Gmail convention, not a standard)
- stripping `+tags` (subaddressing is not universally implemented)
- unicode folding or homoglyph mapping
- domain aliasing (`googlemail.com` → `gmail.com`)

Case is also left alone: the collation already ignores it, so lowercasing would buy nothing while discarding the address as the donor typed it — which is the address we send receipts and tax reports to. RFC 5321 §2.4 reserves local-part case sensitivity to the destination host.

Also returns on the missing-email 400 in `/donors/auth0/register`, which previously fell through to `getIDbyEmail(undefined)` and an insert of a NULL email.

## Testing

`src/__test__/donorEmail.spec.ts` — 10 tests covering the trim behaviour, the four normalizations we refuse to do, and assertions that the trimmed value is what actually reaches SQL on lookup, insert and update. `npm run typecheck` and `format:check` are clean.

**CI is red for reasons unrelated to this PR.** The suite has 17 pre-existing failures on `master` (verified by running it at `6585b4d`); this branch has the same 17, plus 10 new passing tests. `QualityAssurance` only runs on PRs, never on `master`, so the breakage accumulated unnoticed. Causes:

- `mail.sendOcrBackup` was removed in `fa13ab0` ("Deprecates usage of mailgun for emails") but `scheduled.spec.ts:79` and `scheduled.retry.spec.ts:99` still stub it. The throw aborts their `before` hooks, so the app is never set up and the follow-up tests then fail 401 — around 9 of the 17.
- `vipps.spec.ts` does `sinon.replace(authMiddleware, "isAdmin", [])`, but the routers capture `isAdmin` by value at import time, so the replacement is a no-op → 3 × 401.
- `DAO/distributions.spec.ts` calls `getAll(0, 10, { id: "ID" }, null)`, and `"ID"` is no longer in `jsDBmapping` → 4 failures on stale expectations.

## Follow-ups (not in this PR)

- **The 5 dirty rows** (IDs 2753, 2814, 2895, 2978, 8555) are being cleaned up by hand. Trimming each is not sufficient on its own: if the donor has since logged in to Min side they have a duplicate twin, and their Auth0 claim points at the empty one. Check with `SELECT ID, email, date_registered FROM Donors WHERE TRIM(email) = ?`, and prefer merging into whichever row the Auth0 metadata already points at.
- **A DB-level guard.** Application normalization is only as good as the next call site. Moving the constraint onto a generated column makes it collation-independent, and has to run after the manual cleanup or it fails on the existing collisions:
  ```sql
  ALTER TABLE Donors
    MODIFY email VARCHAR(320) NOT NULL,
    ADD COLUMN email_norm VARCHAR(320) GENERATED ALWAYS AS (LOWER(TRIM(email))) STORED,
    ADD UNIQUE KEY email_norm_UNIQUE (email_norm);
  ```
- **Schema drift.** Production's `Donors` does not match what the migration chain produces: `utf8mb4_0900_ai_ci` where `dc49521` specified `utf8mb4_unicode_ci`, and `FULLTEXT KEY search (email, full_name)` where that migration creates a plain BTREE prefix index. That migration's effect on this table is absent in production, and because it is recorded as applied `prisma migrate` will never re-apply it. This is the class of drift that caused the bug.
- **`POST /donors/auth0/register` is unauthenticated.** Combined with sequential ids it is a donor-enumeration oracle, and it lets anyone create donor rows.
- **The donor id claim lives in Auth0 `user_metadata`**, the half of the profile users can be granted write access to. It belongs in `app_metadata`.
