### PR TITLE
Fix merge_donors table coverage and guard self-merge

### DIFF
--- a/prisma/migrations/20260821101500_fix_merge_donors_missing_tables/migration.sql
+++ b/prisma/migrations/20260821101500_fix_merge_donors_missing_tables/migration.sql
@@ -1,0 +1,111 @@
+-- Fix merge_donors to move every table that references Donors.
+--
+-- The procedure moves the source donor's rows to the destination donor and then
+-- deletes the source donor. Any table it forgets is not left behind - it is
+-- destroyed, because these foreign keys are ON DELETE CASCADE:
+--
+--   Funds_donations.DonorID
+--   Swish_orders.donorID
+--   Mailersend_survey_responses.DonorID
+--
+-- and these are ON DELETE SET NULL, so the rows survive but are silently
+-- orphaned from the donor:
+--
+--   Adoveo_fundraiser.Donor_ID
+--   Adoveo_giftcard_transactions.Sender_donor_ID
+--   Adoveo_giftcard_transactions.Receiver_donor_ID
+--
+-- Also adds a guard against merging a donor into itself. That call is not a
+-- no-op today: every UPDATE matches nothing and the DELETE then removes the
+-- donor along with all their donations and distributions.
+
+DROP PROCEDURE IF EXISTS `merge_donors`;
+
+CREATE PROCEDURE `merge_donors`(IN sourceDonorId INT, IN destinationDonorId INT) BEGIN
+	DECLARE finished INTEGER DEFAULT 0;
+	DECLARE currentSsn varchar(11) DEFAULT "";
+    DECLARE selectedTaxUnitId INT;
+
+	# Get all tax units grouped by ssn
+    # Used after the donor is merged
+	DECLARE curSsns CURSOR FOR SELECT ssn FROM Tax_unit WHERE Donor_ID = destinationDonorId GROUP BY ssn HAVING COUNT(ssn)>1;
+
+	DECLARE exit handler for sqlexception
+	BEGIN
+		ROLLBACK;
+        RESIGNAL;
+	END;
+
+	DECLARE exit handler for sqlwarning
+	BEGIN
+		ROLLBACK;
+        RESIGNAL;
+    END;
+
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET finished = 1;
+
+    # Merging a donor into itself would fall through to the DELETE below and
+    # take the donor and everything cascading off them with it
+    IF sourceDonorId = destinationDonorId THEN
+		SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'merge_donors: source and destination donor must differ';
+	END IF;
+
+    # Start merging donor
+    START TRANSACTION;
+
+    UPDATE Distributions SET Donor_ID = destinationDonorId WHERE Donor_ID = sourceDonorId;
+    UPDATE Donations SET Donor_ID = destinationDonorId WHERE Donor_ID = sourceDonorId AND ID > -1;
+    UPDATE Vipps_agreements SET donorID = destinationDonorId WHERE donorID = sourceDonorId AND ID != 'abc';
+    UPDATE Vipps_orders SET donorID = destinationDonorId WHERE donorID = sourceDonorId AND ID > -1;
+    UPDATE Paypal_historic_distributions SET Donor_ID = destinationDonorId WHERE Donor_ID = sourceDonorId AND ID > -1;
+    UPDATE Referral_records SET DonorID = destinationDonorId WHERE DonorID = sourceDonorId AND ID > -1;
+    UPDATE FB_payment_ID SET donorID = destinationDonorId WHERE donorID = sourceDonorId AND ID > -1;
+    UPDATE Tax_unit SET Donor_ID = destinationDonorId WHERE Donor_ID = sourceDonorId AND ID > -1;
+    # Transfer fundraiser ownership before deleting source donor to prevent cascade delete
+    UPDATE Fundraisers SET Donor_ID = destinationDonorId WHERE Donor_ID = sourceDonorId AND ID > -1;
+    # Cascade deletes - these rows are destroyed with the source donor if not moved
+    UPDATE Funds_donations SET DonorID = destinationDonorId WHERE DonorID = sourceDonorId AND ID > -1;
+    UPDATE Swish_orders SET donorID = destinationDonorId WHERE donorID = sourceDonorId AND ID > -1;
+    UPDATE Mailersend_survey_responses SET DonorID = destinationDonorId WHERE DonorID = sourceDonorId AND ID > -1;
+    # Set null on delete - these rows survive but lose the donor reference
+    UPDATE Adoveo_fundraiser SET Donor_ID = destinationDonorId WHERE Donor_ID = sourceDonorId AND ID > -1;
+    UPDATE Adoveo_giftcard_transactions SET Sender_donor_ID = destinationDonorId WHERE Sender_donor_ID = sourceDonorId AND ID > -1;
+    UPDATE Adoveo_giftcard_transactions SET Receiver_donor_ID = destinationDonorId WHERE Receiver_donor_ID = sourceDonorId AND ID > -1;
+
+    DELETE FROM Donors WHERE ID = sourceDonorId;
+
+    # Loop over all where count of ssn > 1
+    OPEN curSsns;
+	consolidateTaxUnits: LOOP
+		FETCH curSsns INTO currentSsn;
+		IF finished = 1 THEN
+			LEAVE consolidateTaxUnits;
+		END IF;
+
+		SELECT ID from Tax_unit WHERE Donor_ID = destinationDonorId AND ssn = currentSsn LIMIT 1 INTO selectedTaxUnitId;
+        UPDATE Distributions
+			SET Tax_unit_ID = selectedTaxUnitId
+            WHERE
+				Donor_ID = destinationDonorId AND
+                Tax_unit_ID IN (SELECT * FROM (SELECT ID FROM Tax_unit WHERE Donor_ID = destinationDonorId AND ssn = currentSsn) as ids);
+
+        # Funds_donations.TaxUnitID is ON DELETE SET NULL, so the rows we just
+        # moved over would quietly lose their tax unit when the duplicate is
+        # dropped below
+        UPDATE Funds_donations
+			SET TaxUnitID = selectedTaxUnitId
+            WHERE
+				DonorID = destinationDonorId AND
+                TaxUnitID IN (SELECT * FROM (SELECT ID FROM Tax_unit WHERE Donor_ID = destinationDonorId AND ssn = currentSsn) as ids);
+
+        DELETE FROM Tax_unit
+			WHERE
+				Donor_ID = destinationDonorId AND
+				ssn = currentSsn AND
+                ID != selectedTaxUnitId;
+    END LOOP consolidateTaxUnits;
+
+    CLOSE curSsns;
+
+    COMMIT;
+END;

--- a/src/routes/donors.ts
+++ b/src/routes/donors.ts
@@ -1400,6 +1400,18 @@ router.post("/:originId/merge/:destinationId", authMiddleware.isAdmin, async (re
       });
     }
 
+    /**
+     * merge_donors moves the origin donor's rows over and then deletes the
+     * origin donor. With the same id on both sides that is a plain delete, and
+     * everything hanging off the donor goes with it via cascade.
+     */
+    if (originId === destinationId) {
+      return res.status(400).json({
+        status: 400,
+        content: "Cannot merge a donor into itself",
+      });
+    }
+
     const donorOrigin = await DAO.donors.getByID(originId);
     const donorDestination = await DAO.donors.getByID(destinationId);
 


### PR DESCRIPTION
## Why

`merge_donors` moves the source donor's rows to the destination donor and then deletes the source donor. It moved 9 of the 15 tables that reference `Donors`. The 6 it missed were not left behind — they were destroyed or orphaned by the foreign keys:

| Table / column | FK rule | Result before this fix |
| --- | --- | --- |
| `Funds_donations.DonorID` | CASCADE | rows deleted |
| `Swish_orders.donorID` | CASCADE | rows deleted |
| `Mailersend_survey_responses.DonorID` | CASCADE | rows deleted |
| `Adoveo_fundraiser.Donor_ID` | SET NULL | donor reference lost |
| `Adoveo_giftcard_transactions.Sender_donor_ID` | SET NULL | donor reference lost |
| `Adoveo_giftcard_transactions.Receiver_donor_ID` | SET NULL | donor reference lost |

This is live data loss on a tool the org uses regularly — merging duplicate donors is routine admin work, and a Swish donation history disappearing during a merge is silent.

## What this changes

All six now move with the donor.

`Funds_donations.TaxUnitID` is also re-pointed during the tax unit consolidation loop at the end of the procedure. That column is `ON DELETE SET NULL`, so the `Funds_donations` rows this PR starts preserving would otherwise quietly lose their tax unit when a duplicate unit is dropped. Only `Distributions` was being re-pointed before.

**Self-merge guard.** `merge_donors(x, x)` was not a no-op: every UPDATE matched nothing, and the DELETE then removed the donor along with all their donations and distributions. Guarded in the procedure (`SIGNAL SQLSTATE '45000'`) and in the route, which also did not check.

The procedure is otherwise byte-identical to the version in `20260109142128_fix_merge_donors_fundraisers` — the diff between the two files is exactly the new UPDATEs plus the guard, nothing else.

## Testing

`npm run typecheck` and `format:check` are clean. **The migration has not been run against a database yet** — it needs a `prisma migrate deploy` on staging, and ideally a manual merge of two throwaway donors that own rows in each of the six tables, before this ships.

**CI is red for reasons unrelated to this PR.** The suite has 17 pre-existing failures on `master`, verified by running it at `6585b4d`; this branch adds none. `QualityAssurance` only runs on PRs, never on `master`, so the breakage accumulated unnoticed. Short version: `mail.sendOcrBackup` was removed in `fa13ab0` but two specs still stub it, which aborts their `before` hooks and cascades into 401s; `vipps.spec.ts` replaces `authMiddleware.isAdmin` after the routers have already captured it by value; and `DAO/distributions.spec.ts` sorts by `"ID"`, which is no longer in `jsDBmapping`. Details in #759.

## Context

Split out of #759, which turned out to be two unrelated fixes in one branch. That PR keeps the email normalization; this one is only the merge procedure. They touch different regions of `src/routes/donors.ts` and merge cleanly in either order.

Both came out of investigating a donor who could log in to Min side but saw no donations: the duplicate donor row was created by the login itself, and the merge used to repair it is the procedure fixed here.
