### PR TITLE
Fix the test suite

### DIFF
--- a/src/__test__/DAO/distributions.spec.ts
+++ b/src/__test__/DAO/distributions.spec.ts
@@ -4,123 +4,90 @@ import { DAO } from "../../custom_modules/DAO";
 
 describe("DAO Distributions", () => {
   describe("getAll", () => {
+    /**
+     * getAll issues two queries: the first fetches the active organizations used
+     * to build the pivot columns, the second is the main paginated query. The
+     * row total rides along on the main query as total_rows rather than coming
+     * from a separate count query, and rows are mapped to donation_sum /
+     * donation_count plus one column per active organization.
+     */
+    const mockActiveOrgs = [{ abbriv: "EFF" }, { abbriv: "AMF" }];
+
+    const mockRow = (KID: string, totalRows: number) => ({
+      KID,
+      full_name: "Test Testesen",
+      email: "testæøå@test.com",
+      donation_sum: 100,
+      donation_count: 2,
+      EFF: "60.000000000000",
+      AMF: "40.000000000000",
+      total_rows: totalRows,
+    });
+
+    const expectedRow = (KID: string) => ({
+      KID,
+      full_name: "Test Testesen",
+      email: "testæøå@test.com",
+      donation_sum: 100,
+      donation_count: 2,
+      EFF: 60,
+      AMF: 40,
+    });
+
+    let queryStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      queryStub = sinon.stub(DAO, "query");
+      queryStub.onFirstCall().resolves([mockActiveOrgs, []]);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it("Gets all distributions with no filter", async () => {
-      const queryStub = sinon.stub(DAO, "query");
+      queryStub.onSecondCall().resolves([[mockRow("123456789", 2), mockRow("987654321", 2)], []]);
 
-      const mockQueryResponse = [
-        {
-          KID: "123456789",
-          sum: 100,
-          count: 2,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-        {
-          KID: "987654321",
-          sum: 200,
-          count: 1,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-      ];
-
-      const mockCountQueryResponse = [
-        {
-          count: 2,
-        },
-      ];
-
-      queryStub.onFirstCall().resolves([mockQueryResponse, []]);
-      queryStub.onSecondCall().resolves([mockCountQueryResponse, []]);
-
-      const result = await DAO.distributions.getAll(0, 10, { id: "ID" }, null);
+      const result = await DAO.distributions.getAll(0, 10, { id: "KID" }, null);
 
       expect(queryStub.calledTwice).to.be.true;
       expect(result).to.deep.equal({
-        rows: mockQueryResponse,
+        rows: [expectedRow("123456789"), expectedRow("987654321")],
+        statistics: { numDistributions: 2 },
         pages: 1,
       });
-      expect(queryStub.firstCall.args[0]).to.not.contain("WHERE");
-      expect(queryStub.firstCall.args[0]).to.contain("LIMIT 10");
-      expect(queryStub.firstCall.args[0]).to.contain("OFFSET 0");
+      expect(queryStub.firstCall.args[0]).to.contain("FROM Organizations");
+      // The filters are the only thing that puts a LIKE in the main query
+      expect(queryStub.secondCall.args[0]).to.not.contain("LIKE");
+      expect(queryStub.secondCall.args[0]).to.contain("LIMIT 10");
+      expect(queryStub.secondCall.args[0]).to.contain("OFFSET 0");
     });
 
     it("Gets all distributions with filter", async () => {
-      const queryStub = sinon.stub(DAO, "query");
-
-      const mockQueryResponse = [
-        {
-          KID: "123456789",
-          sum: 100,
-          count: 2,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-        {
-          KID: "987654321",
-          sum: 200,
-          count: 1,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-      ];
-
-      const mockCountQueryResponse = [
-        {
-          count: 2,
-        },
-      ];
-
-      queryStub.onFirstCall().resolves([mockQueryResponse, []]);
-      queryStub.onSecondCall().resolves([mockCountQueryResponse, []]);
+      queryStub.onSecondCall().resolves([[mockRow("123456789", 2), mockRow("987654321", 2)], []]);
 
       const result = await DAO.distributions.getAll(
         0,
         10,
-        { id: "ID" },
+        { id: "KID" },
         { donor: "Test Testesen" },
       );
 
       expect(queryStub.calledTwice).to.be.true;
       expect(result).to.deep.equal({
-        rows: mockQueryResponse,
+        rows: [expectedRow("123456789"), expectedRow("987654321")],
+        statistics: { numDistributions: 2 },
         pages: 1,
       });
-      expect(queryStub.firstCall.args[0]).to.contain("WHERE");
-      expect(queryStub.firstCall.args[0]).to.contain("Test Testesen");
-      expect(queryStub.firstCall.args[0]).to.contain("LIKE");
-      expect(queryStub.firstCall.args[0]).to.contain("LIMIT 10");
-      expect(queryStub.firstCall.args[0]).to.contain("OFFSET 0");
+      expect(queryStub.secondCall.args[0]).to.contain("WHERE");
+      expect(queryStub.secondCall.args[0]).to.contain("Test Testesen");
+      expect(queryStub.secondCall.args[0]).to.contain("LIKE");
+      expect(queryStub.secondCall.args[0]).to.contain("LIMIT 10");
+      expect(queryStub.secondCall.args[0]).to.contain("OFFSET 0");
     });
 
     it("Gets all distributions with filter and order", async () => {
-      const queryStub = sinon.stub(DAO, "query");
-
-      const mockQueryResponse = [
-        {
-          KID: "123456789",
-          sum: 100,
-          count: 2,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-        {
-          KID: "987654321",
-          sum: 200,
-          count: 1,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-      ];
-
-      const mockCountQueryResponse = [
-        {
-          count: 2,
-        },
-      ];
-
-      queryStub.onFirstCall().resolves([mockQueryResponse, []]);
-      queryStub.onSecondCall().resolves([mockCountQueryResponse, []]);
+      queryStub.onSecondCall().resolves([[mockRow("123456789", 2), mockRow("987654321", 2)], []]);
 
       const result = await DAO.distributions.getAll(
         0,
@@ -131,67 +98,47 @@ describe("DAO Distributions", () => {
 
       expect(queryStub.calledTwice).to.be.true;
       expect(result).to.deep.equal({
-        rows: mockQueryResponse,
+        rows: [expectedRow("123456789"), expectedRow("987654321")],
+        statistics: { numDistributions: 2 },
         pages: 1,
       });
-      expect(queryStub.firstCall.args[0]).to.contain("WHERE");
-      expect(queryStub.firstCall.args[0]).to.contain("Test Testesen");
-      expect(queryStub.firstCall.args[0]).to.contain("LIKE");
-      expect(queryStub.firstCall.args[0]).to.contain("ORDER BY sum DESC");
-      expect(queryStub.firstCall.args[0]).to.contain("LIMIT 10");
-      expect(queryStub.firstCall.args[0]).to.contain("OFFSET 0");
+      expect(queryStub.secondCall.args[0]).to.contain("WHERE");
+      expect(queryStub.secondCall.args[0]).to.contain("Test Testesen");
+      expect(queryStub.secondCall.args[0]).to.contain("LIKE");
+      // "sum" maps to the donation_sum alias, not to a bare "sum" column
+      expect(queryStub.secondCall.args[0]).to.contain("ORDER BY donation_sum DESC");
+      expect(queryStub.secondCall.args[0]).to.contain("LIMIT 10");
+      expect(queryStub.secondCall.args[0]).to.contain("OFFSET 0");
     });
 
     it("Gets all distributions with correct pages counter when there are more rows than the limit", async () => {
-      const queryStub = sinon.stub(DAO, "query");
+      queryStub
+        .onSecondCall()
+        .resolves([
+          [mockRow("111111111", 3), mockRow("222222222", 3), mockRow("333333333", 3)],
+          [],
+        ]);
 
-      const mockQueryResponse = [
-        {
-          KID: "987654321",
-          sum: 200,
-          count: 1,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-        {
-          KID: "987654321",
-          sum: 200,
-          count: 1,
-          full_name: "Glor Gorgesen Testesen",
-          email: "asd@test.com",
-        },
-        {
-          KID: "987654321",
-          sum: 200,
-          count: 1,
-          full_name: "Test Testesen",
-          email: "testæøå@test.com",
-        },
-      ];
-
-      const mockCountQueryResponse = [
-        {
-          count: 3,
-        },
-      ];
-
-      queryStub.onFirstCall().resolves([mockQueryResponse, []]);
-      queryStub.onSecondCall().resolves([mockCountQueryResponse, []]);
-
-      const result = await DAO.distributions.getAll(0, 1, { id: "ID" }, null);
+      const result = await DAO.distributions.getAll(0, 1, { id: "KID" }, null);
 
       expect(queryStub.calledTwice).to.be.true;
       expect(result).to.deep.equal({
-        rows: mockQueryResponse,
+        rows: [expectedRow("111111111"), expectedRow("222222222"), expectedRow("333333333")],
+        statistics: { numDistributions: 3 },
         pages: 3,
       });
-      expect(queryStub.firstCall.args[0]).to.not.contain("WHERE");
-      expect(queryStub.firstCall.args[0]).to.contain("LIMIT 1");
-      expect(queryStub.firstCall.args[0]).to.contain("OFFSET 0");
+      expect(queryStub.secondCall.args[0]).to.not.contain("LIKE");
+      expect(queryStub.secondCall.args[0]).to.contain("LIMIT 1");
+      expect(queryStub.secondCall.args[0]).to.contain("OFFSET 0");
     });
 
-    afterEach(() => {
-      sinon.restore();
+    it("Rejects a sort column that is not in the mapping", async () => {
+      try {
+        await DAO.distributions.getAll(0, 10, { id: "ID" }, null);
+        throw new Error("Promise did not reject as expected");
+      } catch (ex) {
+        expect(ex.message).to.contain("Invalid sort column: ID");
+      }
     });
   });
 

--- a/src/__test__/scheduled.retry.spec.ts
+++ b/src/__test__/scheduled.retry.spec.ts
@@ -61,7 +61,6 @@ describe("POST /scheduled/avtalegiro/retry", function () {
   let loggingStub;
   let sendFileStub;
   let getShipmentIdsStub;
-  let sendMailBackupStub;
   let authStub;
   let dueDateStub;
   let getConnectionStub;
@@ -95,8 +94,6 @@ describe("POST /scheduled/avtalegiro/retry", function () {
     loggingStub = sinon.stub(DAO.logging, "add").resolves();
 
     sendFileStub = sinon.stub(nets, "sendFile");
-
-    sendMailBackupStub = sinon.stub(mail, "sendOcrBackup");
 
     const scheduledRoute = require("../routes/scheduled");
     server = express();

--- a/src/__test__/scheduled.spec.ts
+++ b/src/__test__/scheduled.spec.ts
@@ -51,7 +51,6 @@ describe("POST /scheduled/avtalegiro", function () {
   let agreementsStub;
   let loggingStub;
   let sendFileStub;
-  let sendMailBackupStub;
   let authStub;
 
   before(function () {
@@ -76,8 +75,6 @@ describe("POST /scheduled/avtalegiro", function () {
 
     sendFileStub = sinon.stub(nets, "sendFile");
 
-    sendMailBackupStub = sinon.stub(mail, "sendOcrBackup");
-
     const scheduledRoute = require("../routes/scheduled");
     server = express();
     server.use("/scheduled", scheduledRoute);
@@ -98,7 +95,6 @@ describe("POST /scheduled/avtalegiro", function () {
     expect(sendNotificationStub.called).to.be.false;
     expect(sendFileStub.called).to.be.false;
     expect(loggingStub.calledOnce).to.be.true;
-    expect(sendMailBackupStub.calledOnce).to.be.true;
   });
 
   it("Generates claim file when provided a date", async function () {


### PR DESCRIPTION
## Why CI was red

`QualityAssurance` only runs on pull requests, never on `master` — master merges go through `BackendDeploy`, which doesn't run the tests. So 17 failures accumulated unnoticed, and every open PR inherits them.

Two root causes account for all 17.

**`mail.sendOcrBackup` no longer exists.** It was removed in `fa13ab0` ("Deprecates usage of mailgun for emails", 2025-06-06); the only reference left in `src` is a commented-out call at `routes/scheduled.ts:375`. But `scheduled.spec.ts:79` and `scheduled.retry.spec.ts:99` still did `sinon.stub(mail, "sendOcrBackup")`, and sinon throws on a non-existent property.

Both stubs sit in `before` hooks *ahead of* `require("../routes/scheduled")`. So the throw meant the router was never mounted while `authMiddleware.isAdmin` was replaced with `[]`. Every later suite that reused the cached module got the real JWT middleware instead and failed with `401 Unauthorized` — which is why the failures looked like an auth problem in `vipps.spec.ts` and `/initiate-follow-ups` when the actual cause was a deleted mail function. Dropping the two dead stubs and the assertion on the mail that is no longer sent fixes **13 of the 17**.

**`DAO/distributions.spec.ts` encoded the old `getAll` contract.** The implementation now:

- issues two queries — active organizations for the pivot columns, *then* the main paginated query — where the tests assumed main-query-then-count-query, so every SQL assertion was inspecting the organizations query
- carries the row total on the main query as `total_rows` instead of a separate count query
- maps rows to `donation_sum` / `donation_count` plus one column per active organization
- returns `statistics` alongside `rows` and `pages`

The tests also sorted by `{ id: "ID" }`, which is not in `jsDBmapping`, so `getAll` threw `Invalid sort column: ID` before doing any work — that alone accounted for 3 of the 4. Rewritten against the current contract, asserting on the main query rather than the organizations one, with shared row builders instead of four copies of the same fixture.

I added one test that didn't exist: `Rejects a sort column that is not in the mapping`. That rejection path is what silently swallowed the other failures, so it's worth pinning.

## Result

180 tests, from 17 failing to 0.

Locally I get 179 passing / 1 failing, and that last one is an artifact of my machine rather than the code:

```
Error: The module '.../libxmljs/build/Release/xmljs.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 127. This version of Node.js requires NODE_MODULE_VERSION 108.
```

`libxmljs` is a native module. I ran the suite under Node 18 to match CI, against a `node_modules` built under Node 22, so the compiled binary is for the wrong ABI. CI does its own `npm install` under its own Node, so this one resolves there — this PR's CI run is the real check.

`npm run typecheck` and `format:check` are clean.

## Follow-up

`QualityAssurance` not running on `master` is the reason this was invisible for over a year. Worth adding the same build as a post-merge trigger, or making it a required check, so the next regression surfaces on the commit that causes it rather than on an unrelated PR months later.

Node 18 has been EOL since April 2025 — a Node upgrade follows in a separate PR, on top of this one.
