### PR TITLE
Stop the unsendable emails from reporting success

### DIFF
--- a/src/__test__/mail.unsent.spec.ts
+++ b/src/__test__/mail.unsent.spec.ts
@@ -1,0 +1,51 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import * as mail from "../custom_modules/mail";
+
+/**
+ * These six emails lost their mailgun implementation and never gained a
+ * MailerSend template. They used to return true, so all 17 call sites believed
+ * the mail had gone out. These tests pin the opposite: they must report failure
+ * and say so in the log, until someone rebuilds them.
+ *
+ * When one is rebuilt, its case here should fail - that is the point. Move it
+ * out of this list and test the real send instead.
+ */
+describe("emails with no MailerSend template", function () {
+  const sandbox = sinon.createSandbox();
+  let errorStub: sinon.SinonStub;
+
+  beforeEach(function () {
+    errorStub = sandbox.stub(console, "error");
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  const cases: Array<[string, () => Promise<unknown>]> = [
+    ["sendFacebookTaxConfirmation", () => mail.sendFacebookTaxConfirmation("a@b.no", "A B", "1")],
+    ["sendVippsAgreementChange", () => mail.sendVippsAgreementChange("code", "STOPPED")],
+    ["sendVippsErrorWarning", () => mail.sendVippsErrorWarning("DRAFT", "boom", {})],
+    ["sendVippsProblemReport", () => mail.sendVippsProblemReport("url", "a@b.no", "message", null)],
+    ["sendAvtaleGiroChange", () => mail.sendAvtaleGiroChange("123", "AMOUNT", "500")],
+    ["sendAvtalegiroRegistered", () => mail.sendAvtalegiroRegistered(null)],
+  ];
+
+  cases.forEach(([name, invoke]) => {
+    it(`${name} reports failure rather than claiming success`, async function () {
+      const result = await invoke();
+
+      expect(result, "must not report success while sending nothing").to.equal(false);
+    });
+
+    it(`${name} logs an error naming itself`, async function () {
+      await invoke();
+
+      expect(errorStub.calledOnce).to.be.true;
+      const message = errorStub.firstCall.args[0];
+      expect(message).to.contain("[unsent-email]");
+      expect(message).to.contain(name);
+    });
+  });
+});

--- a/src/custom_modules/mail.ts
+++ b/src/custom_modules/mail.ts
@@ -600,11 +600,33 @@ export async function sendPaymentIntentFollowUp(
 }
 
 /**
+ * These six emails were sent through mailgun until it was deprecated. No
+ * MailerSend template was ever created to replace them - confirmed against the
+ * MailerSend template list - so they cannot be sent at all.
+ *
+ * They used to log a warning and return true, which all 17 call sites read as
+ * "sent". An AvtaleGiro registration confirmation, a Vipps agreement change
+ * notice and a donor-reported Vipps problem have therefore been disappearing
+ * silently. Report the failure instead, so it shows up in logs and so callers
+ * that pass the result on are telling the truth.
+ *
+ * Deliberately does not throw: several call sites sit directly after a payment
+ * agreement has been created or changed, and failing to send a notification
+ * must not roll that back.
+ */
+function unsentDeprecatedEmail(emailName: string): false {
+  console.error(
+    `[unsent-email] ${emailName} was not sent: the mailgun implementation was ` +
+      `removed and no MailerSend template replaced it.`,
+  );
+  return false;
+}
+
+/**
  * @param {string} email
  */
 export async function sendFacebookTaxConfirmation(email, fullName, paymentID) {
-  console.warn("Deprecated mailgun facebook tax confirmation email, use mailersend instead");
-  return true; // TODO: Remove this when we have migrated all facebook emails to mailersend
+  return unsentDeprecatedEmail("sendFacebookTaxConfirmation");
 }
 
 /**
@@ -613,8 +635,7 @@ export async function sendFacebookTaxConfirmation(email, fullName, paymentID) {
  * @param {string} newValue New value of what was changed (if applicable)
  */
 export async function sendVippsAgreementChange(agreementCode, change, newValue = null) {
-  console.warn("Deprecated mailgun vipps agreement change email, use mailersend instead");
-  return true; // TODO: Remove this when we have migrated all vipps emails to mailersend
+  return unsentDeprecatedEmail("sendVippsAgreementChange");
 }
 
 /**
@@ -623,8 +644,7 @@ export async function sendVippsAgreementChange(agreementCode, change, newValue =
  * @param {string} inputData The input data while the error happened
  */
 export async function sendVippsErrorWarning(errorType, errorMessage, inputData) {
-  console.warn("Deprecated mailgun vipps problem report email, use mailersend instead");
-  return true; // TODO: Remove this when we have migrated all vipps emails to mailersend
+  return unsentDeprecatedEmail("sendVippsErrorWarning");
 }
 
 /**
@@ -634,8 +654,7 @@ export async function sendVippsErrorWarning(errorType, errorMessage, inputData) 
  * @param {VippsAgreement} agreement Vipps agreement data
  */
 export async function sendVippsProblemReport(senderUrl, senderEmail, donorMessage, agreement) {
-  console.warn("Deprecated mailgun vipps problem report email, use mailersend instead");
-  return true; // TODO: Remove this when we have migrated all vipps emails to mailersend
+  return unsentDeprecatedEmail("sendVippsProblemReport");
 }
 
 /**
@@ -648,14 +667,13 @@ export async function sendAvtaleGiroChange(
   change: "CANCELLED" | "AMOUNT" | "CHARGEDAY" | "SHARES",
   newValue: string | number = "",
 ) {
-  console.warn("Deprecated mailgun avtalegiro change email, use mailersend instead");
-  return true; // TODO: Remove this when we have migrated all avtalegiro emails to mailersend
+  return unsentDeprecatedEmail("sendAvtaleGiroChange");
 }
 
 /**
  * Sends donors with avtalegiro agreement a notification of an upcomming claim
  * @param {import('./parsers/avtalegiro.js').AvtalegiroAgreement} agreement
- * @returns {true | number} True if successfull, or an error code if failed
+ * @returns {false} Always false: this email has no MailerSend template yet
  */
 export async function sendAvtalegiroNotification(
   agreement: AvtaleGiroAgreement,
@@ -712,11 +730,10 @@ export async function sendAvtalegiroNotification(
 /**
  * Sends donors with who just registered an AvtaleGiro an email confirming it
  * @param {import('./parsers/avtalegiro.js').AvtalegiroAgreement} agreement
- * @returns {true | number} True if successfull, or an error code if failed
+ * @returns {false} Always false: this email has no MailerSend template yet
  */
 export async function sendAvtalegiroRegistered(agreement: AvtaleGiroAgreement) {
-  console.warn("Deprecated mailgun avtalegiro registered email, use mailersend instead");
-  return true; // TODO: Remove this when we have migrated all avtalegiro emails to mailersend
+  return unsentDeprecatedEmail("sendAvtalegiroRegistered");
 }
 
 /**


### PR DESCRIPTION
Stacked on #764 — base is `remove-dead-templates`, so the diff shows only this change. Retarget to `master` once #764 merges.

## The problem

Six exported mail functions lost their mailgun implementation and never gained a MailerSend template. **Confirmed against MailerSend (`GET /v1/templates`, 22 templates): none of the six exists there.** They logged a `console.warn` and returned `true`, and all 17 call sites read that as "sent".

So, today, in production:

- a donor registers an **AvtaleGiro agreement** → no confirmation email
- a donor **changes or stops a Vipps agreement** → no notice
- a donor **reports a Vipps problem** → the report reaches nobody, and they get a success response

with nothing in the logs beyond a warning nobody greps for.

## What this changes

`return false`, and log at error level behind a greppable `[unsent-email]` prefix so it surfaces in Cloud Logging and to anything watching stderr.

**Deliberately not throwing.** Several call sites sit immediately after a payment agreement has been created or changed — `avtalegiro.ts:259` runs right after registering an agreement — and failing to send a notification must not roll that back.

## One behaviour change to be aware of

Two endpoints pass the result straight to the client via `res.json(response)`, so their response body changes from `true` to `false`:

- `POST /vipps/agreement/notify/change`
- `POST /vipps/agreement/report/problem`

That's the point rather than a side effect — a donor reporting a Vipps problem currently gets a success response while the report goes nowhere. But **the frontend will need to handle it**, and those routes arguably ought to return a 5xx rather than `200 false`. I didn't change the status codes, since that's a wider API decision than this PR should make.

The other 15 call sites ignore the return value, so they're unaffected apart from the log line.

## Tests

`src/__test__/mail.unsent.spec.ts` — 12 tests, two per function: it must return `false`, and it must log an error naming itself. 217 passing overall, `typecheck` and `format:check` clean.

The tests are written to become a to-do list: **when one of these emails is rebuilt, its case here starts failing.** That's the signal to move it out of the list and test the real send instead.

## Follow-up

`sendVippsProblemReport` and `sendVippsErrorWarning` are internal staff alerts, and MailerSend sends plain `html`/`text` with no template — so those two can be fixed without any template design work. The four donor-facing ones need templates built; `SV_AutoGiroRegistered` is a usable model for a Norwegian AvtaleGiro equivalent.
