### PR TITLE
Send the two Vipps staff alerts as plain mail again

### DIFF
--- a/src/__test__/mail.internalAlerts.spec.ts
+++ b/src/__test__/mail.internalAlerts.spec.ts
@@ -1,0 +1,85 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import * as mail from "../custom_modules/mail";
+
+/**
+ * The two Vipps alerts go to staff rather than donors, so they are sent as
+ * plain text and HTML with no MailerSend template behind them.
+ *
+ * The delivery itself is not covered here: the MailerSend client is
+ * constructed inside the send, so exercising the happy path would mean a real
+ * HTTP call. What is covered is the formatting, and the refusal to claim
+ * success when the alert cannot be addressed.
+ */
+describe("internal alerts", function () {
+  describe("formatInternalAlert", function () {
+    it("renders every field in both text and html", function () {
+      const { text, html } = mail.formatInternalAlert("Noe feilet", [
+        ["Tidspunkt", "1. januar 2026"],
+        ["Feiltype", "DRAFT"],
+      ]);
+
+      expect(text).to.contain("Noe feilet");
+      expect(text).to.contain("Tidspunkt: 1. januar 2026");
+      expect(text).to.contain("Feiltype: DRAFT");
+
+      expect(html).to.contain("<strong>Noe feilet</strong>");
+      expect(html).to.contain("Tidspunkt:");
+      expect(html).to.contain("DRAFT");
+    });
+
+    it("escapes html so a donor message cannot inject markup", function () {
+      const { html } = mail.formatInternalAlert("Rapport", [
+        ["Melding", '<script>alert("x")</script> & "quoted"'],
+      ]);
+
+      expect(html).to.not.contain("<script>");
+      expect(html).to.contain("&lt;script&gt;");
+      expect(html).to.contain("&amp;");
+      expect(html).to.contain("&quot;");
+    });
+
+    it("keeps the plain text unescaped", function () {
+      const { text } = mail.formatInternalAlert("Rapport", [["Melding", "a & b"]]);
+
+      expect(text).to.contain("a & b");
+    });
+  });
+
+  /**
+   * MAILERSEND_API_KEY is unset in the test environment, which is the branch
+   * these assert - and which also keeps them off the network. Returning false
+   * here is the whole point: the previous implementation returned true while
+   * sending nothing.
+   */
+  describe("when MailerSend is not configured", function () {
+    const sandbox = sinon.createSandbox();
+    let errorStub: sinon.SinonStub;
+
+    beforeEach(function () {
+      errorStub = sandbox.stub(console, "error");
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it("sendVippsProblemReport reports failure and names the missing configuration", async function () {
+      const result = await mail.sendVippsProblemReport("url", "a@b.no", "melding", null);
+
+      expect(result).to.equal(false);
+      expect(errorStub.calledOnce).to.be.true;
+      expect(errorStub.firstCall.args[0]).to.contain("sendVippsProblemReport");
+      expect(errorStub.firstCall.args[0]).to.contain("MAILERSEND_API_KEY");
+    });
+
+    it("sendVippsErrorWarning reports failure and names the missing configuration", async function () {
+      const result = await mail.sendVippsErrorWarning("DRAFT", "boom", { kid: "1" });
+
+      expect(result).to.equal(false);
+      expect(errorStub.calledOnce).to.be.true;
+      expect(errorStub.firstCall.args[0]).to.contain("sendVippsErrorWarning");
+      expect(errorStub.firstCall.args[0]).to.contain("MAILERSEND_API_KEY");
+    });
+  });
+});

--- a/src/__test__/mail.unsent.spec.ts
+++ b/src/__test__/mail.unsent.spec.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 import * as mail from "../custom_modules/mail";
 
 /**
- * These six emails lost their mailgun implementation and never gained a
+ * These four emails lost their mailgun implementation and never gained a
  * MailerSend template. They used to return true, so all 17 call sites believed
  * the mail had gone out. These tests pin the opposite: they must report failure
  * and say so in the log, until someone rebuilds them.
@@ -26,8 +26,6 @@ describe("emails with no MailerSend template", function () {
   const cases: Array<[string, () => Promise<unknown>]> = [
     ["sendFacebookTaxConfirmation", () => mail.sendFacebookTaxConfirmation("a@b.no", "A B", "1")],
     ["sendVippsAgreementChange", () => mail.sendVippsAgreementChange("code", "STOPPED")],
-    ["sendVippsErrorWarning", () => mail.sendVippsErrorWarning("DRAFT", "boom", {})],
-    ["sendVippsProblemReport", () => mail.sendVippsProblemReport("url", "a@b.no", "message", null)],
     ["sendAvtaleGiroChange", () => mail.sendAvtaleGiroChange("123", "AMOUNT", "500")],
     ["sendAvtalegiroRegistered", () => mail.sendAvtalegiroRegistered(null)],
   ];

--- a/src/custom_modules/mail.ts
+++ b/src/custom_modules/mail.ts
@@ -600,6 +600,84 @@ export async function sendPaymentIntentFollowUp(
 }
 
 /**
+ * Renders an internal alert as both plain text and minimal HTML. Kept pure so
+ * the formatting can be tested without touching MailerSend.
+ */
+export function formatInternalAlert(
+  title: string,
+  rows: Array<[string, string]>,
+): { text: string; html: string } {
+  const text = [title, "", ...rows.map(([label, value]) => `${label}: ${value}`)].join("\n");
+  const html =
+    `<p><strong>${escapeHtml(title)}</strong></p>` +
+    "<ul>" +
+    rows
+      .map(
+        ([label, value]) => `<li><strong>${escapeHtml(label)}:</strong> ${escapeHtml(value)}</li>`,
+      )
+      .join("") +
+    "</ul>";
+  return { text, html };
+}
+
+function escapeHtml(value: string): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Shared inbox for technical alerts, as used by sendSanitySecurityNotice. */
+const TECHNICAL_INBOX = "teknisk@gieffektivt.no";
+
+/**
+ * Sends an alert to the team without a MailerSend template. These go to staff
+ * rather than donors, so there is nothing to design - a subject and a list of
+ * fields is the whole requirement, and MailerSend accepts html/text directly.
+ *
+ * Sent from and to the technical inbox, the same destination
+ * sendSanitySecurityNotice uses. gieffektivt.no is a verified sending domain,
+ * and a plain send has to name a sender - unlike the template sends, which
+ * inherit one from the template.
+ *
+ * The api key is checked rather than assumed, so a misconfigured environment
+ * reports the alert as unsent instead of failing somewhere inside the SDK. It
+ * also keeps the tests off the network.
+ */
+async function sendInternalAlert(params: {
+  alertName: string;
+  subject: string;
+  text: string;
+  html: string;
+}): Promise<boolean> {
+  if (!config.mailersend_api_key) {
+    console.error(
+      `[unsent-email] ${params.alertName} was not sent: MAILERSEND_API_KEY is not configured.`,
+    );
+    return false;
+  }
+
+  const mailersend = new MailerSend({ apiKey: config.mailersend_api_key });
+
+  const email = new EmailParams()
+    .setFrom(new Sender(TECHNICAL_INBOX, "Gi Effektivt"))
+    .setTo([new Recipient(TECHNICAL_INBOX)])
+    .setSubject(params.subject)
+    .setText(params.text)
+    .setHtml(params.html);
+
+  try {
+    await mailersend.email.send(email);
+    return true;
+  } catch (ex) {
+    console.error(`[unsent-email] ${params.alertName} failed to send`);
+    console.error(ex);
+    return false;
+  }
+}
+
+/**
  * These six emails were sent through mailgun until it was deprecated. No
  * MailerSend template was ever created to replace them - confirmed against the
  * MailerSend template list - so they cannot be sent at all.
@@ -644,7 +722,26 @@ export async function sendVippsAgreementChange(agreementCode, change, newValue =
  * @param {string} inputData The input data while the error happened
  */
 export async function sendVippsErrorWarning(errorType, errorMessage, inputData) {
-  return unsentDeprecatedEmail("sendVippsErrorWarning");
+  const errorDesc =
+    errorType === "DRAFT"
+      ? "Oppretting av Vipps betalingsavtale feilet"
+      : errorType === "CHARGE"
+      ? "Trekk av Vipps betalingsavtale feilet"
+      : `Ukjent Vipps-feil (${errorType})`;
+
+  const { text, html } = formatInternalAlert(errorDesc, [
+    ["Tidspunkt", formatTimestamp(new Date())],
+    ["Feiltype", String(errorType)],
+    ["Feilmelding", typeof errorMessage === "string" ? errorMessage : JSON.stringify(errorMessage)],
+    ["Inndata", JSON.stringify(inputData)],
+  ]);
+
+  return await sendInternalAlert({
+    alertName: "sendVippsErrorWarning",
+    subject: `Varsling om systemfeil - ${errorDesc}`,
+    text,
+    html,
+  });
 }
 
 /**
@@ -654,7 +751,20 @@ export async function sendVippsErrorWarning(errorType, errorMessage, inputData) 
  * @param {VippsAgreement} agreement Vipps agreement data
  */
 export async function sendVippsProblemReport(senderUrl, senderEmail, donorMessage, agreement) {
-  return unsentDeprecatedEmail("sendVippsProblemReport");
+  const { text, html } = formatInternalAlert("Problem med Vipps betalingsavtale", [
+    ["Tidspunkt", formatTimestamp(new Date())],
+    ["Donor", String(senderEmail)],
+    ["Melding", String(donorMessage)],
+    ["Side", String(senderUrl)],
+    ["Avtale", JSON.stringify(agreement)],
+  ]);
+
+  return await sendInternalAlert({
+    alertName: "sendVippsProblemReport",
+    subject: "En donor har rapportert et problem med Vipps",
+    text,
+    html,
+  });
 }
 
 /**


### PR DESCRIPTION
Stacked on #765 (which is stacked on #764). Retarget as those merge.

## Why these two first

`sendVippsProblemReport` and `sendVippsErrorWarning` go to the team, not to donors. A subject and a list of fields is the whole requirement, and MailerSend accepts `html`/`text` directly — so these two are the only members of the unsendable six that need **no template design work at all**.

`sendVippsProblemReport` is also the one with real urgency: a donor reports a problem with their Vipps agreement, the form tells them it worked, and the report reaches nobody.

## Addressing

Both go **from and to `teknisk@gieffektivt.no`**, hardcoded — the destination `sendSanitySecurityNotice` already uses. No new environment variable.

The mailgun originals hard-coded two personal addresses at `effektivaltruisme.no`, which isn't a domain this repo sends from any more; a shared inbox is a better destination for a technical alert than a list of individuals anyway. A plain send has to name a sender (unlike the template sends, which inherit one from the template), and `gieffektivt.no` is verified with DKIM and SPF.

The MailerSend API key is checked rather than assumed, so a misconfigured environment reports the alert as unsent instead of failing somewhere inside the SDK — and so the tests stay off the network.

## Escaping

`formatInternalAlert` is exported and pure, so the formatting is testable without touching MailerSend — and it escapes HTML. That matters here: the Vipps problem report interpolates a **donor-supplied message** straight into the body, so `<script>` in a donor's complaint would otherwise land as markup in a staff inbox.

## Tests

218 passing. Five new tests cover the formatting (text and HTML, escaping, and that plain text stays unescaped) and the refusal to claim success when unconfigured.

The two functions also came out of `mail.unsent.spec.ts`, exactly as that file's comment said they should — that spec is now down to the remaining donor-facing emails.

**Not covered: actual delivery.** The MailerSend client is constructed inside the send, so exercising the happy path would mean a real HTTP call from CI. This wants one manual end-to-end check after deploy — trigger a Vipps problem report and confirm it lands in `teknisk@`.

## Remaining

| Email | Status |
|---|---|
| `sendFacebookTaxConfirmation` | confirmed dead — to be deleted with its 4 call sites |
| `sendAvtalegiroRegistered` | needs template, synthesised from `SV_AutoGiroRegistered` + historical HTML |
| `sendAvtaleGiroChange` | needs template |
| `sendVippsAgreementChange` | needs template |
