### PR TITLE
Remove the dead Facebook tax confirmation email

### DIFF
--- a/src/__test__/mail.unsent.spec.ts
+++ b/src/__test__/mail.unsent.spec.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 import * as mail from "../custom_modules/mail";
 
 /**
- * These four emails lost their mailgun implementation and never gained a
+ * These three emails lost their mailgun implementation and never gained a
  * MailerSend template. They used to return true, so all 17 call sites believed
  * the mail had gone out. These tests pin the opposite: they must report failure
  * and say so in the log, until someone rebuilds them.
@@ -24,7 +24,6 @@ describe("emails with no MailerSend template", function () {
   });
 
   const cases: Array<[string, () => Promise<unknown>]> = [
-    ["sendFacebookTaxConfirmation", () => mail.sendFacebookTaxConfirmation("a@b.no", "A B", "1")],
     ["sendVippsAgreementChange", () => mail.sendVippsAgreementChange("code", "STOPPED")],
     ["sendAvtaleGiroChange", () => mail.sendAvtaleGiroChange("123", "AMOUNT", "500")],
     ["sendAvtalegiroRegistered", () => mail.sendAvtalegiroRegistered(null)],

--- a/src/custom_modules/mail.ts
+++ b/src/custom_modules/mail.ts
@@ -701,13 +701,6 @@ function unsentDeprecatedEmail(emailName: string): false {
 }
 
 /**
- * @param {string} email
- */
-export async function sendFacebookTaxConfirmation(email, fullName, paymentID) {
-  return unsentDeprecatedEmail("sendFacebookTaxConfirmation");
-}
-
-/**
  * @param {string} agreementCode
  * @param {"PAUSED" | "UNPAUSED" | "STOPPED" | "AMOUNT" | "CHARGEDAY" | "SHARES"} change What change was done
  * @param {string} newValue New value of what was changed (if applicable)

--- a/src/routes/facebook.ts
+++ b/src/routes/facebook.ts
@@ -5,7 +5,6 @@ import e from "express";
 import express from "express";
 const router = express.Router();
 import * as authMiddleware from "../custom_modules/authorization/authMiddleware";
-import { sendFacebookTaxConfirmation } from "../custom_modules/mail";
 import { fetchToken } from "../custom_modules/facebook";
 import { donationHelpers } from "../custom_modules/donationHelpers";
 
@@ -78,8 +77,6 @@ router.post("/register/payment", async (req, res, next) => {
         await DAO.donations.transferDonationsFromDummy(donorID, dummyDonor.ID, taxUnitID);
       }
     }
-
-    await sendFacebookTaxConfirmation(email, full_name, paymentID);
 
     res.json({
       status: 200,

--- a/src/routes/mail.ts
+++ b/src/routes/mail.ts
@@ -3,7 +3,6 @@ import { DAO } from "../custom_modules/DAO";
 import {
   sendDonationRegistered,
   sendAvtalegiroNotification,
-  sendFacebookTaxConfirmation,
   sendSanitySecurityNotice,
   sendMissingTaxUnitNotice,
 } from "../custom_modules/mail";
@@ -43,23 +42,6 @@ router.post("/avtalegiro/notice", authMiddleware.isAdmin, async (req, res, next)
     }
 
     await sendAvtalegiroNotification(agreement, claimDate);
-
-    res.json({
-      status: 200,
-      content: "OK",
-    });
-  } catch (ex) {
-    next(ex);
-  }
-});
-
-router.post("/facebook/tax/confirmation", authMiddleware.isAdmin, async (req, res, next) => {
-  try {
-    const recipient = req.body.recipient;
-    const name = req.body.name;
-    const paymentID = req.body.paymentID;
-
-    await sendFacebookTaxConfirmation(recipient, name, paymentID);
 
     res.json({
       status: 200,


### PR DESCRIPTION
Stacked on #766. Retarget as the stack merges.

Facebook fundraising is over, so this email isn't coming back and there's no point building a MailerSend template for it. It has been a no-op returning `true` since mailgun was deprecated.

## Removed

- `sendFacebookTaxConfirmation` itself
- the call in `routes/facebook.ts`
- **`POST /mail/facebook/tax/confirmation`** — an admin-only endpoint that existed for no other purpose than to send this email

That endpoint has been answering `200 OK` while doing nothing, so anything still calling it was already getting nothing. **But if the admin panel has a button wired to it, that button needs removing too** — it'll start 404ing instead of silently succeeding. Worth a grep in the admin repo.

The rest of `routes/facebook.ts` stays: registering tax units against historical Facebook donations is a separate concern from the email.

## Tests

216 passing. `mail.unsent.spec.ts` is down to three cases — the donor-facing emails that still need templates built.
